### PR TITLE
feat: 新規登録機能の基本実装（サインアップ・ログイン・ルート振り分け）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # 全てのアクションで認証チェックを行う
+  before_action :authenticate_user!
+
+  # Devise利用時のストロングパラメータを設定するためのフック
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected #privateではない理由は継承クラス（Deviseクラスから呼び出しOKにするため）
+
+  # Deviseのパラメータを許可するメソッド
+  def configure_permitted_parameters
+    # 新規登録の際に、nameのデータ操作を許可する
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,0 +1,4 @@
+class DashboardsController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,0 +1,2 @@
+module DashboardsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,17 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # Deviseの認証モジュールを設定
+  # :database_authenticatable（パスワード認証）
+  # :registerable（ユーザー登録・編集）
+  # :recoverable（パスワードリセット）
+  # :rememberable（「ログイン情報を記憶する」チェックボックス）
+  # :validatable（メールアドレスとパスワードのバリデーション）
+  # ※ その他、:confirmable, :lockable, :timeoutable, :trackable, :omniauthable などが必要に応じて追加可能
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :recoverable, :rememberable, :validatable
+
+  # 名前（name）は登録時のみ必要
+  validates :name, presence: true
+
+  validates :name, length: { maximum: 50 }
+
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Dashboards#index</h1>
+<p>Find me in app/views/dashboards/index.html.erb</p>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,101 @@
+<%# ページのタイトル %>
 <h2>Sign up</h2>
 
+<%# Ruby on Railsヘルパー: form_for (Deviseの認証フォーム開始) %>
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
 
+  <%# 名前（name）の入力欄 %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :name %><br /> <%# Railsフォームヘルパー: name属性のラベルを表示 %>
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+    <%# Railsフォームヘルパー: テキスト入力フィールドを生成 %>
   </div>
 
+  <%# Eメールの入力欄 %>
   <div class="field">
-    <%= f.label :password %>
+    <%= f.label :email %><br /> <%# Railsフォームヘルパー: email属性のラベルを表示 %>
+    <%= f.email_field :email, autocomplete: "email" %>
+    <%# Railsフォームヘルパー: Eメール形式の入力フィールドを生成 %>
+  </div>
+
+  <%# パスワードの入力欄 %>
+  <div class="field">
+    <%= f.label :password %> <%# Railsフォームヘルパー: password属性のラベルを表示 %>
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <%# Ruby/ERBロジック: パスワード最小文字数（Deviseから提供されるインスタンス変数）を表示 %>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
+    <%# Railsフォームヘルパー: パスワード入力フィールドを生成 %>
   </div>
 
+  <%# パスワード確認の入力欄 %>
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation %><br /> <%# Railsフォームヘルパー: password_confirmationのラベルを表示 %>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%# Railsフォームヘルパー: パスワード入力フィールドを生成 %>
   </div>
 
+  <%# 登録ボタン %>
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "Sign up" %> <%# Railsフォームヘルパー: フォーム送信ボタンを生成 %>
   </div>
 <% end %>
 
+<%# Devise 認証関連のリンク %>
 <%= render "devise/shared/links" %>
+<%# Deviseが提供する共通パーシャル（_links.html.erb）を読み込み、ログインやパスワードリセットリンクを表示 %>
+
+<%# ページのタイトル %>
+<h2>Sign up</h2>
+
+<%# Ruby on Railsヘルパー: form_for (Deviseの認証フォーム開始) %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+
+  <%# 【Devise共通機能】バリデーションエラーメッセージの表示 %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%# Deviseが提供する共通パーシャル（_error_messages.html.erb）を読み込みます。
+    # フォーム送信失敗時に、Userモデル（resource）のエラー内容を整形して表示します。 %>
+
+  <%# 名前（name）の入力欄 %>
+  <div class="field">
+    <%= f.label :name %><br /> <%# Railsフォームヘルパー: name属性のラベルを表示 %>
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+    <%# Railsフォームヘルパー: テキスト入力フィールドを生成 %>
+  </div>
+
+  <%# Eメールの入力欄 %>
+  <div class="field">
+    <%= f.label :email %><br /> <%# Railsフォームヘルパー: email属性のラベルを表示 %>
+    <%= f.email_field :email, autocomplete: "email" %>
+    <%# Railsフォームヘルパー: Eメール形式の入力フィールドを生成 %>
+  </div>
+
+  <%# パスワードの入力欄 %>
+  <div class="field">
+    <%= f.label :password %> <%# Railsフォームヘルパー: password属性のラベルを表示 %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <%# Ruby/ERBロジック: パスワード最小文字数（Deviseから提供されるインスタンス変数）を表示 %>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%# Railsフォームヘルパー: パスワード入力フィールドを生成 %>
+  </div>
+
+  <%# パスワード確認の入力欄 %>
+  <div class="field">
+    <%= f.label :password_confirmation %><br /> <%# Railsフォームヘルパー: password_confirmationのラベルを表示 %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%# Railsフォームヘルパー: パスワード入力フィールドを生成 %>
+  </div>
+
+  <%# 登録ボタン %>
+  <div class="actions">
+    <%= f.submit "Sign up" %> <%# Railsフォームヘルパー: フォーム送信ボタンを生成 %>
+  </div>
+<% end %>
+
+
+<%# 【Devise共通機能】認証関連のリンク %>
+<%= render "devise/shared/links" %>
+<%# Deviseが提供する共通パーシャル（_links.html.erb）を読み込み、ログインやパスワードリセットリンクを表示 %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <h2>Log in</h2>
-
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+  <% end %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,55 @@
 Rails.application.routes.draw do
+  # ダッシュボードへのGETルートを定義（コントローラとアクションを紐付け）
+  get "dashboards/index"
 
-  # Deviseのルート定義
+  # Deviseの認証機能に必要な全ルーティングを生成
   devise_for :users
 
-  # アプリケーションのルート設定
-
-  # Deviseのログイン画面をアプリケーションのルート ( "/") に設定する
-  # devise_scopeを使うことで、DeviseにUserモデルのコンテキストを教えている
-  devise_scope :user do
-    root to: 'devise/sessions#new' # ログイン画面 (/users/sign_in) へルーティング
+  # 認証済みユーザー向けのルート設定
+  # Userモデルでログインしている場合（user_signed_in?がtrueの場合）に適用
+  authenticated :user do
+    # ルートパス ("/") を DashboardsControllerのindexアクションに設定
+    root to: 'dashboards#index', as: :authenticated_root
   end
-end
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    # ルートパス ("/") を Deviseのログイン画面（sessions#new）に設定
+    root to: 'devise/sessions#new'
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,14 @@
 Rails.application.routes.draw do
 
-  # --- Devise (認証機能) のルート定義 ---
-
-  # Userモデルのサインアップ、ログイン、ログアウトなどのルーティングを定義
+  # Deviseのルート定義
   devise_for :users
 
-  # --- アプリケーションのルート設定 ---
+  # アプリケーションのルート設定
 
-  # アプリケーションのルートパス ("/") にアクセスがあった場合、Deviseのログイン画面を表示
-  root to: "devise/sessions#new"
-
-  # --- Rails 標準機能のルート ---
-
-  # ヘルスチェック用のルート。外部監視ツールなどがアプリの稼働状況を確認するために使用。
-  get "up" => "rails/health#show", as: :rails_health_check
-
+  # Deviseのログイン画面をアプリケーションのルート ( "/") に設定する
+  # devise_scopeを使うことで、DeviseにUserモデルのコンテキストを教えている
+  devise_scope :user do
+    root to: 'devise/sessions#new' # ログイン画面 (/users/sign_in) へルーティング
+  end
 end
+

--- a/db/migrate/20250926084620_add_name_to_users.rb
+++ b/db/migrate/20250926084620_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNmaeToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/migrate/20250926084620_add_name_to_users.rb
+++ b/db/migrate/20250926084620_add_name_to_users.rb
@@ -1,4 +1,4 @@
-class AddNmaeToUsers < ActiveRecord::Migration[8.0]
+class AddNameToUsers < ActiveRecord::Migration[8.0]
   def change
     add_column :users, :name, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_074615) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_084620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_074615) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DashboardsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get dashboards_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
Deviseを使用したユーザー認証機能のユーザー登録機能とログイン画面を実装しました。

これにより、ユーザーは「名前」「メールアドレス」「パスワード」で新規登録、ログインできるようになり、認証状態に応じてアプリケーションのルートパスが以下のように切り替わります。

認証済み（ログイン後）: ダッシュボード画面へリダイレクト

未認証（ログアウト状態）: ログイン画面へリダイレクト

### 変更点
以下のファイルで変更を行いました。

1. ルーティング設定 (config/routes.rb)
- authenticated :user: ログイン済みのユーザーのルートパス (/) をダッシュボード (dashboards#index) に設定

- devise_scope :user: 未ログイン状態のルートパス (/) をDeviseのログイン画面 (devise/sessions#new) に設定

- DashboardsControllerへのアクセスに必要な get "dashboards/index" ルートを追加

2. コントローラとビューの追加
- DashboardsControllerとそのビュー (app/views/dashboards/index.html.erb) を作成

3. 新規登録画面の修正 (app/views/devise/registrations/new.html.erb)
- ユーザー管理の要件に基づき、名前 (:name) の入力フィールドを追加しました。

### 動作確認
以下の手順で動作確認をお願いします。

- [x] アプリケーションのルートパス (/) にアクセスする。
→ ログイン画面が表示されることを確認

- [x] ログイン画面の「新規登録」リンクから、新しいユーザー情報（名前、メール、パスワード）を入力して登録する
→ 新規登録完了後、自動的にダッシュボード画面 (/dashboards/index もしくは /) へ遷移することを確認

- [x] 先ほど登録したメールアドレスとパスワードでログインする
→ ログイン後、ダッシュボード画面へ遷移することを確認