### PR TITLE
feat: 原材料管理に必要なCategoryとMaterialモデルの定義

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,10 @@
 class Category < ApplicationRecord
+  # ユーザーとの関連付け
   belongs_to :user
+  # Materialモデルとの関連付け
+  has_many :materials, dependent: :destroy
+  # カテゴリ名が空欄でないこと、一意であることを要求
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+  # カテゴリ分類が空欄でないことを要求
+  validates :category_type, presence: true
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,0 +1,4 @@
+class Material < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,4 +1,18 @@
 class Material < ApplicationRecord
   belongs_to :user
   belongs_to :category
+
+  # 各バリデーションを設定
+  validates :name, presence: true
+  validates :unit_for_product, presence: true
+  validates :unit_for_order, presence: true
+
+  # 数値項目は必須かつ0より大きい値のみ許可（エラー回避）
+  validates :unit_weight_for_product,
+            presence: true,
+            numericality: { greater_than: 0 }
+
+  validates :unit_weight_for_order,
+            presence: true,
+            numericality: { greater_than: 0 }
 end

--- a/db/migrate/20250928015704_create_categories.rb
+++ b/db/migrate/20250928015704_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false         # 必須
+      t.string :category_type, null: false # 必須
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250928015704_create_categories.rb
+++ b/db/migrate/20250928015704_create_categories.rb
@@ -7,5 +7,8 @@ class CreateCategories < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
+
+    # ユーザーIDと名前の組み合わせでユニークインデックスを追加
+    add_index :categories, [:user_id, :name], unique: true
   end
 end

--- a/db/migrate/20250928015715_create_materials.rb
+++ b/db/migrate/20250928015715_create_materials.rb
@@ -1,0 +1,15 @@
+class CreateMaterials < ActiveRecord::Migration[8.0]
+  def change
+    create_table :materials do |t|
+      t.string :name
+      t.string :unit_for_product
+      t.decimal :unit_weight_for_product, precision: 10, scale: 3, null: false # 精度を指定
+      t.string :unit_for_order
+      t.decimal :unit_weight_for_order, precision: 10, scale: 3, null: false # 精度を指定
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250928015715_create_materials.rb
+++ b/db/migrate/20250928015715_create_materials.rb
@@ -1,13 +1,13 @@
 class CreateMaterials < ActiveRecord::Migration[8.0]
   def change
     create_table :materials do |t|
-      t.string :name
-      t.string :unit_for_product
+      t.string :name, null: false  # 必須
+      t.string :unit_for_product, null: false # 必須
       t.decimal :unit_weight_for_product, precision: 10, scale: 3, null: false # 精度を指定
-      t.string :unit_for_order
+      t.string :unit_for_order, null: false # 必須
       t.decimal :unit_weight_for_order, precision: 10, scale: 3, null: false # 精度を指定
-      t.references :user, null: false, foreign_key: true
-      t.references :category, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true # 必須
+      t.references :category, null: false, foreign_key: true # 必須
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_084620) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_28_015715) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "category_type", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_categories_on_user_id"
+  end
+
+  create_table "materials", force: :cascade do |t|
+    t.string "name"
+    t.string "unit_for_product"
+    t.decimal "unit_weight_for_product", precision: 10, scale: 3, null: false
+    t.string "unit_for_order"
+    t.decimal "unit_weight_for_order", precision: 10, scale: 3, null: false
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_materials_on_category_id"
+    t.index ["user_id"], name: "index_materials_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +49,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_084620) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "categories", "users"
+  add_foreign_key "materials", "categories"
+  add_foreign_key "materials", "users"
 end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  category_type: MyString
+  user: one
+
+two:
+  name: MyString
+  category_type: MyString
+  user: two

--- a/test/fixtures/materials.yml
+++ b/test/fixtures/materials.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  unit_for_product: MyString
+  unit_weight_for_product: 9.99
+  unit_for_order: MyString
+  unit_weight_for_order: 9.99
+  user: one
+  category: one
+
+two:
+  name: MyString
+  unit_for_product: MyString
+  unit_weight_for_product: 9.99
+  unit_for_order: MyString
+  unit_weight_for_order: 9.99
+  user: two
+  category: two

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MaterialTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
原材料管理機能の準備として、`Category`および`Material`モデルとそのデータベース構造を定義し、データの整合性を設定しました。

## 変更点

### 1. モデルの追加
- `Category`モデル
- `Material`モデル

### 2. マイグレーションとデータベーススキーマの定義
- **依存関係解消:** `Category`テーブルを先に定義することで、`Material`テーブルの外部キーエラーを解消
- **データ型:** `Material`の重量カラム（`unit_weight_for_product`, `unit_weight_for_order`）に、`precision: 10, scale: 3`を適用し、小数の精度を確保

### 3. バリデーションとアソシエーション
- **Category:** `name`は`user_id`スコープでユニーク制約を設定。`name`と`category_type`を必須としました
- **Material:** 全ての必須項目（`name`, `unit_for_product`, `unit_weight_for_product`など）に`presence: true`を設定
　　　　　　重量カラムには`numericality: { greater_than_or_equal_to: 0 }`を設定
- **Userモデル:** `has_many :materials, dependent: :destroy`を追加し、ユーザー削除時のデータ連鎖削除を設定

## 確認事項
- [ ] マイグレーションファイル (`db/migrate/`) のカラム定義と制約に問題がないか
- [ ] 各モデルのバリデーション（特に`uniqueness: { scope: :user_id }`）が要件を満たしているか