### PR TITLE
feat: カテゴリー一覧機能（CRUD基盤）の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,10 @@ class ApplicationController < ActionController::Base
     # アカウント編集の際に、nameのデータ操作を許可する
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
+
+  # Deviseでのログイン成功後に遷移するパスを明示的に指定
+  def after_sign_in_path_for(resource)
+    # 認証済みユーザーのルートパスへ遷移
+    authenticated_root_path
+  end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,24 @@
+class CategoriesController < ApplicationController
+  def index
+    # 複数形注意。昇順に並べます。
+    @categories = Category.all.order(name: :asc)
+  end
+
+  def new
+    @Category = Category.new
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  private
+
+  def Category_params
+    # name属性のみ安全に受付
+    params.require(:Category).permit(:name)
+  end
+end
+

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Categories#edit</h1>
+<p>Find me in app/views/categories/edit.html.erb</p>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Categories#index</h1>
+<p>Find me in app/views/categories/index.html.erb</p>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,2 +1,23 @@
-<h1>Categories#index</h1>
-<p>Find me in app/views/categories/index.html.erb</p>
+<%# 一時的な土台を作成 %>
+<h1>カテゴリー一覧</h1>
+
+<table class="table">
+
+  <tbody>
+    <% @categories.each do |category| %>
+      <tr>
+        <td><%= category.name %></td>
+
+        <td>
+          <%# リンク先は category オブジェクトから自動生成 %>
+          <%= link_to '詳細', category %> |
+
+          <%= link_to '編集', edit_category_path(category) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%# 新規作成ページへの導線%>
+<%= link_to '新規カテゴリー作成', new_category_path, class: "btn btn-primary mt-3" %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Categories#new</h1>
+<p>Find me in app/views/categories/new.html.erb</p>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Categories#show</h1>
+<p>Find me in app/views/categories/show.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  get "categories/index"
+  get "categories/show"
+  get "categories/new"
+  get "categories/edit"
   # ダッシュボードへのGETルートを定義（コントローラとアクションを紐付け）
   get "dashboards/index"
 
@@ -16,4 +20,10 @@ Rails.application.routes.draw do
     # ルートパス ("/") を Deviseのログイン画面（sessions#new）に設定
     root to: "devise/sessions#new"
   end
+
+  # Category の CRUD ルーティングを一括定義
+  resources :categories
+
+  # Material のルーティングも将来のために定義しておく
+  resources :materials
 end

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get categories_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get categories_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get categories_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get categories_edit_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
カテゴリーの一覧表示機能を実装しました。これにより、認証済みユーザーは登録されている全カテゴリーをブラウザ上で確認できます。
尚、登録機能は次の工程で実装しますので、そちらで再度確認をお願いいたします。

## 変更内容
###  Controller
- `CategoriesController` を追加し、index アクションを定義。`@categories = Category.all.order(name: :asc)` で 
  全カテゴリーを名前の昇順で取得するように設定

###  View 
- `@categories` をループ処理するテーブル形式のUIを実装

### Routes 
- `resources :categories` を追加し、CRUDに必要な全ルーティングを生成

## 動作確認
- [x] 未ログイン時に /categories にアクセスすると、ログイン画面にリダイレクトされること
- [x]  /categories にアクセスすると、画面にカテゴリー一覧のテキストが出力させること
