### PR TITLE
feat: Devise認証機能とCategory機能のI18n化を実施

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -14,7 +14,7 @@ class CategoriesController < ApplicationController
 
     # メッセージ追加: 新規作成成功
     if @category.save
-      redirect_to categories_path, notice: "カテゴリー「#{@category.name}」を新規作成しました。"
+      redirect_to categories_path, notice: t('controllers.create.success', resource: Category.model_name.human)
     else
       render :new
     end
@@ -30,7 +30,7 @@ class CategoriesController < ApplicationController
 
     if @category.update(category_params)
       # 更新成功したら一覧画面へリダイレクト
-      redirect_to categories_path, notice: "カテゴリー「#{@category.name}」を更新しました。"
+      redirect_to categories_path, notice: t('controllers.update.success', resource: Category.model_name.human)
     else
       # 更新失敗したら編集画面を再表示
       render :edit
@@ -43,7 +43,7 @@ class CategoriesController < ApplicationController
     # レコードを削除
     @category.destroy
     # 削除成功後、一覧画面へリダイレクト
-    redirect_to categories_path, notice: "カテゴリー「#{@category.name}」を削除しました。"
+      redirect_to categories_path, notice: t('controllers.destroy.success', resource: Category.model_name.human)
   end
 
 

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,4 +1,7 @@
-<h1>カテゴリー編集</h1>
+<h1><%= t('.title') %></h1>
+
+<%# エラーパーシャルを呼び出し、@categoryを渡す %>
+<%= render 'shared/error_messages', resource: @category %>
 
 <%# form_withに @category を渡すことで、自動的に update アクションへ送信 %>
 <%= form_with model: @category do |f| %>
@@ -13,8 +16,8 @@
     <%= f.select :category_type, Category.category_types.keys %>
   </div %>
 
-  <%= f.submit "更新" %>
+  <%= f.submit t("helpers.submit.update") %>
 <% end %>
 
 <hr>
-<%= link_to 'カテゴリー一覧へ戻る', categories_path %>
+<%= link_to t('helpers.link.back'), categories_path %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,13 @@
-<%# 一時的な土台を作成 %>
-<h1>カテゴリー一覧</h1>
+<h1><%= t('.title') %></h1>
 
 <table class="table">
+
+    <thead>
+      <tr>
+        <th><%= Category.human_attribute_name(:name) %></th>
+        <th><%= t('helpers.action') %></th>
+      </tr>
+    </thead>
 
   <tbody>
     <% @categories.each do |category| %>
@@ -9,19 +15,19 @@
         <td><%= category.name %></td>
 
         <td>
-          <%= link_to '編集', edit_category_path(category) %>
+          <%= link_to t('helpers.link.edit'), edit_category_path(category) %>
 
-          <%= link_to '削除', category_path(category),
-                      data: { turbo_method: :delete } %>
-
+          <%= link_to t('helpers.link.destroy'), category_path(category),
+            data: {
+              "turbo-method": "delete",
+              "turbo-confirm": t('helpers.confirm.destroy', resource: t('activerecord.models.category'))
+            },
+            class: "btn btn-danger btn-sm" %>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%# 新規作成ページへの導線%>
-<%= link_to '新規カテゴリー作成', new_category_path, class: "btn btn-primary mt-3" %>
-
-<%# ✅ ダッシュボードへの導線を追加 %>
-<%= link_to 'ダッシュボードへ戻る', authenticated_root_path, class: "btn btn-secondary mt-3" %>
+<%= link_to t('helpers.link.new', resource: Category.model_name.human), new_category_path, class: "btn btn-primary mt-3" %>
+<%= link_to t('helpers.link.back_to_dashboard'), authenticated_root_path, class: "btn btn-secondary mt-3" %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,4 +1,7 @@
-<h1>新規カテゴリー登録</h1>
+<h1><%= t('.title') %></h1>
+
+<%# パーシャルを呼び出し、@categoryを渡す %>
+<%= render 'shared/error_messages', resource: @category %>
 
 <%# form_withに model: @category を渡すことで、新規作成（createアクションへのPOST）と自動的に判断される %>
 <%= form_with model: @category do |f| %>
@@ -14,7 +17,7 @@
     <%= f.select :category_type, Category.category_types.keys %>
   </div %>
 
-  <%= f.submit "登録" %>
+  <%= f.submit t("helpers.submit.create") %>
 <% end %>
 <%# 一覧画面へのリンク %>
-<%= link_to 'カテゴリー一覧へ戻る', categories_path %>
+<%= link_to t('helpers.link.back'), categories_path %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -2,28 +2,28 @@
 
   <%# 左側ナビゲーションエリアの土台 %>
   <div class="col-md-3 bg-light border-end p-4">
-    <h2>メニュー</h2>
+    <h2><%= t('dashboard.menu.title') %></h2>
     <div class="list-group">
       <%# ダッシュボード %>
-      <%= link_to 'ダッシュボード', authenticated_root_path, class: "list-group-item list-group-item-action active" %>
+      <%= link_to t('dashboard.menu.dashboard'), authenticated_root_path, class: "list-group-item list-group-item-action active" %>
 
       <%# カテゴリー管理　%>
-      <%= link_to 'カテゴリー管理', categories_path, class: "list-group-item list-group-item-action" %>
+      <%= link_to t('dashboard.menu.category_management'), categories_path, class: "list-group-item list-group-item-action" %>
 
       <hr>
       <%# アカウント設定 %>
-      <%= link_to 'アカウント設定', edit_user_registration_path, class: "list-group-item list-group-item-action" %>
+      <%= link_to t('dashboard.menu.account_settings'), edit_user_registration_path, class: "list-group-item list-group-item-action" %>
 
       <%# ログアウトの修正 %>
       <%= button_to destroy_user_session_path, method: :delete, class: "list-group-item list-group-item-action text-danger mt-2" do %>
-        ログアウト
+        <%= t('devise.sessions.sign_out') %>
       <% end %>
     </div>
   </div>
 
   <%# 右側メインコンテンツエリアの土台 %>
   <div class="col-md-9 p-4">
-    <h1>ようこそ！ <%= current_user.name %> さんのダッシュボード</h1>
+    <h1><%= t('dashboard.welcome_message', name: current_user.name) %></h1>
     <p class="mt-4">メインコンテンツはここに表示されます</p>
   </div>
 </div>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('devise.mailer.reset_password_instructions.greeting', name: @resource.name) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_1') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to t('devise.mailer.reset_password_instructions.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_2') %></p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_3') %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,24 +1,26 @@
-<h2>Change your password</h2>
+<h2><%= t(".title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">
-    <%= f.label :password, "New password" %><br />
+    <%= f.label :password,  t("activerecord.attributes.user.password") %><br />
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <small class="text-muted">
+        <%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %>
+      </small><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.label :password_confirmation, t("activerecord.attributes.user.password_confirmation") %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit t(".submit") %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t("devise.registrations.edit.heading") %></h2>
+<h2><%= t("devise.registrations.edit.title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -33,19 +33,22 @@
   </div>
 
   <div class="field">
-    <i><%= t("devise.registrations.edit.current_password_hint") %></i><br />
+    <%= f.label :current_password, t('activerecord.attributes.user.current_password') %><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
     <%= f.submit t("helpers.submit.update") %>
 
-  <%= link_to t("helpers.submit.destroy"), registration_path(resource_name),
+  <%= button_to t("devise.registrations.edit.cancel_my_account"), registration_path(resource_name),
+    method: :delete,
     data: {
       confirm: t("devise.registrations.edit.confirm_delete"),
       turbo_confirm: t("devise.registrations.edit.confirm_delete")
     },
-    method: :delete %>
+    class: "btn btn-outline-danger" %>
+
   </div>
 <% end %>
-<%= link_to t("helpers.link.back"), root_path %>
+<%= link_to t("helpers.link.back"), authenticated_root_path %>
+

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t("devise.registrations.edit.title") %></h2>
+<h2><%= t(".title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -14,7 +14,9 @@
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div>
+      <%= t('devise.registrations.pending_reconfirmation', unconfirmed_email: resource.unconfirmed_email) %>
+    </div>
   <% end %>
 
   <div class="field">
@@ -39,16 +41,17 @@
 
   <div class="actions">
     <%= f.submit t("helpers.submit.update") %>
-
-  <%= button_to t("devise.registrations.edit.cancel_my_account"), registration_path(resource_name),
-    method: :delete,
-    data: {
-      confirm: t("devise.registrations.edit.confirm_delete"),
-      turbo_confirm: t("devise.registrations.edit.confirm_delete")
-    },
-    class: "btn btn-outline-danger" %>
-
   </div>
 <% end %>
+  <div class="actions">
+    <%= button_to t("devise.registrations.edit.cancel_my_account"), registration_path(resource_name),
+      method: :delete,
+      data: {
+        confirm: t("devise.registrations.edit.confirm_delete"),
+        turbo_confirm: t("devise.registrations.edit.confirm_delete")
+      },
+      class: "btn btn-outline-danger" %>
+  </div>
+
 <%= link_to t("helpers.link.back"), authenticated_root_path %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,36 +1,42 @@
 <div class="row justify-content-center">
-<div class="col-lg-6 col-md-8">
-<div class="card p-4">
-<h1 class="card-title text-center mb-4">寿司管理システム</h1>
-<%= render "devise/shared/tabs" %>
+  <div class="col-lg-6 col-md-8">
+    <div class="card p-4">
+      <h1 class="card-title text-center mb-4"><%= t('devise.system_title') %></h1>
+      <%= render "devise/shared/tabs" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-<%= render "devise/shared/error_messages", resource: resource %>
-<div class="mb-3">
-<%= f.label :name, class: "form-label" %><br />
-<%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
-</div>
-<div class="mb-3">
-<%= f.label :email, class: "form-label" %><br />
-<%= f.email_field :email, autocomplete: "email", class: "form-control" %>
-</div>
-<div class="mb-3">
-<%= f.label :password, class: "form-label" %>
-<% if @minimum_password_length %>
-<small class="text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
-<% end %>
-<%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
-</div>
-<div class="mb-3">
-<%= f.label :password_confirmation, class: "form-label" %><br />
-<%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
-</div>
-<div class="d-grid gap-2">
-<%= f.submit t("devise.registrations.new.submit"), class: "btn btn-success" %>
-</div>
-<% end %>
-<%= render "devise/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-</div>
-</div>
+        <div class="mb-3">
+          <%= f.label :name, class: "form-label" %><br />
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :email, class: "form-label" %><br />
+          <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :password, class: "form-label" %>
+          <% if @minimum_password_length %>
+            <small class="text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :password_confirmation, class: "form-label" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+        </div>
+
+        <div class="d-grid gap-2">
+          <%= f.submit t("devise.registrations.new.submit"), class: "btn btn-success" %>
+        </div>
+      <% end %>
+
+      <%= render "devise/shared/links" %>
+
+    </div>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row justify-content-center">
   <div class="col-lg-6 col-md-8">
     <div class="card p-4">
-      <h1 class="card-title text-center mb-4">寿司管理システム</h1>
+      <h1 class="card-title text-center mb-4"><%= t('devise.system_title') %></h1>
       <%= render "devise/shared/tabs" %>
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>

--- a/app/views/devise/shared/_tabs.html.erb
+++ b/app/views/devise/shared/_tabs.html.erb
@@ -1,11 +1,11 @@
 <ul class="nav nav-tabs mb-4">
   <li class="nav-item">
-    <%= link_to 'ログイン', new_user_session_path,
+    <%= link_to t('devise.sessions.new.sign_in'), new_user_session_path,
       data: { turbo_frame: '_top' },
       class: "nav-link #{'active' if current_page?(new_user_session_path)}" %>
   </li>
   <li class="nav-item">
-    <%= link_to '新規登録', new_user_registration_path,
+    <%= link_to t('devise.shared.links.sign_up'), new_user_registration_path,
       data: { turbo_frame: '_top' },
       class: "nav-link #{'active' if current_page?(new_user_registration_path)}" %>
   </li>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,21 @@
+<%# エラーを保持しているモデルオブジェクト %>
+<% if resource.errors.any? %>
+  <%# Bootstrapを使用 %>
+  <div id="error_explanation" class="alert alert-danger" role="alert">
+
+    <%# I18n化: エラー数とモデル名を動的に表示 %>
+    <h2>
+      <%= t('errors.messages.not_saved',
+            count: resource.errors.count,
+            # モデル名をI18nで取得
+            resource: resource.class.model_name.human)
+      %>
+    </h2>
+
+    <ul class="mb-0">
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,14 @@ ja:
     index:
       title: "カテゴリー一覧"
 
+  dashboard: # 新規追加
+    menu:
+      title: "メニュー"
+      dashboard: "ダッシュボード"
+      category_management: "カテゴリー管理"
+      account_settings: "アカウント設定"
+    welcome_message: "ようこそ！ %{name} さんのダッシュボード"
+
   helpers:
     submit:
       create: "登録"
@@ -60,6 +68,7 @@ ja:
         submit: "ログイン"
       signed_in: "ログインしました。"
       signed_out: "ログアウトしました。"
+      sign_out: "ログアウト"
 
     confirmations:
       confirmed: "アカウントを認証しました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -62,6 +62,7 @@ ja:
       not_found: "が見つかりません"
 
   devise:
+    system_title: "寿司管理システム"
     sessions:
       new:
         sign_in: "ログイン"
@@ -85,6 +86,7 @@ ja:
         title: "アカウント編集"
         cancel_my_account: "アカウンを削除する"
       signed_up: "アカウント登録が完了しました。"
+      pending_reconfirmation: "現在、%{unconfirmed_email} の確認待ちです。"
       user:
         updated: "アカウント情報が正常に更新されました。"
         destroyed: "アカウントを削除しました。"
@@ -101,6 +103,18 @@ ja:
       new:
         forgot_your_password: "パスワードを忘れた方"
         submit: "パスワード再設定のメールを送信"
+      edit:
+        title: "パスワードの変更"
+        submit: "パスワードを変更"
+
+    mailer:
+      reset_password_instructions:
+        subject: "【寿司管理システム】パスワード再設定のご案内"
+        greeting: "こんにちは %{name} さん！"
+        action: "パスワードの変更"
+        instruction_1: "パスワードをリセットするには、以下のリンクをクリックしてください。"
+        instruction_2: "このメールに心当たりがない場合は、無視して構いません。"
+        instruction_3: "パスワードは、上記のリンクをクリックして新しいパスワードを作成するまで変更されません。"
 
   activerecord:
     errors:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,13 +3,39 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
 
+  controllers:
+    create:
+      success: "%{resource}を作成しました。"
+    update:
+      success: "%{resource}を更新しました。"
+    destroy:
+      success: "%{resource}を削除しました。"
+
+  categories:
+    new:
+      title: "新規カテゴリー登録"
+    edit:
+      title: "カテゴリー編集"
+    index:
+      title: "カテゴリー一覧"
+
   helpers:
     submit:
+      create: "登録"
       update: "更新"
       destroy: "削除"
 
+    action: "アクション"
+
+    confirm:
+      destroy: "本当にこの%{resource}を削除してもよろしいですか？"
+
     link: # リンクのテキストを追加
       back: "戻る"
+      edit: "編集"
+      destroy: "削除"
+      new: "新規%{resource}作成"
+      back_to_dashboard: "ダッシュボードへ戻る"
 
     label:
       user:
@@ -24,6 +50,8 @@ ja:
         other: "%{count} 文字以上で入力してください"
       taken: "は既に使用されています"
       confirmation: "と%{attribute}の入力が一致しません"
+      invalid: "が正しくありません"
+      not_found: "が見つかりません"
 
   devise:
     sessions:
@@ -45,10 +73,12 @@ ja:
       new:
         submit: "登録"
       edit:
-        heading: "ユーザー編集"
-        current_password_hint: "現在のパスワード"
+        title: "アカウント編集"
+        cancel_my_account: "アカウンを削除する"
       signed_up: "アカウント登録が完了しました。"
-      confirm_delete: "本当にアカウントを削除してもよろしいですか？"
+      user:
+        updated: "アカウント情報が正常に更新されました。"
+        destroyed: "アカウントを削除しました。"
 
     shared:
       minimum_password_length: "(%{count}文字以上)"
@@ -59,7 +89,6 @@ ja:
     passwords:
       send_instructions: "パスワード再設定のメールを送信しました。"
       updated: "パスワードを変更しました。"
-
       new:
         forgot_your_password: "パスワードを忘れた方"
         submit: "パスワード再設定のメールを送信"
@@ -73,7 +102,9 @@ ja:
               not_found: "メールアドレスが見つかりません"
 
     models:
-      user: "ユーザー"
+      user: "アカウント"
+      category: "カテゴリー"
+      material: "原材料"
 
     attributes:
       user:
@@ -81,3 +112,12 @@ ja:
         password: "パスワード"
         name: "名前"
         password_confirmation: "パスワード（確認）"
+        current_password: "現在のパスワード"
+
+      category:
+        name: "名称"
+        category_type: "カテゴリー種別"
+        category_types:
+          material: "原材料"
+          product: "商品"
+          plan: "計画"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   devise_scope :user do
     # ルートパス ("/") を Deviseのログイン画面（sessions#new）に設定
     root to: "devise/sessions#new"
+
+    # GET /users リクエストをログインページ（/）へリダイレクトしてエラーを防ぐ
+    get '/users', to: redirect('/')
   end
 
   # showアクションのみを除外


### PR DESCRIPTION
 ## 概要Devise認証機能とCategory機能のI18n化を実施しました。
## 変更内容
###  `config/locales/ja.yml`:
- Devise関連のメッセージ、タイトル、ボタンテキストを日本語化しました
- アカウント編集の確認待ちメッセージ `pending_reconfirmation` を追加しました
- `activerecord` のモデル名（user, category, material）と属性名を日本語化しました

###  Devise ビューテンプレートの修正:
- **パスワード変更画面 (`devise/passwords/edit.html.erb`)**:
    - タイトル、ラベル、送信ボタンをI18n化。Lazy Lookup (`t(".title")`、`t(".submit")`) を使用

-  **アカウント編集画面 (`devise/registrations/edit.html.erb`)**:
    - *更新ボタンと削除ボタンの動作が競合し、更新時に削除が実行される可能性があったため、`button_to` をメインフォーム (`form_for`) の外に完全に分離しました。これにより、意図しない削除を防ぎました

## 動作確認

- [x] ログイン、ログアウト、新規登録が日本語で表示されることを確認
- [x] パスワードリセットメールが日本語で送信されることを確認
- [x] アカウント編集で 「更新」を押してもアカウントが削除されない ことを確認
- [x] アカウント編集でメールアドレス変更後、確認待ちメッセージが日本語で表示されることを確認