### PR TITLE
Refacotr/material message i18n

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -16,11 +16,14 @@ class MaterialsController <  AuthenticatedController
     @material = current_user.materials.build(material_params)
 
     if @material.save
-      # 'redirect_to'で遷移
+      # 'モデル名を参照する'
+      flash[:notice] = t('controllers.create.success', resource: Material.model_name.human)
       redirect_to materials_path
     else
       # 'render'で再表示
-      render :new
+      flash.now[:alert] = t('controllers.create.failure', resource: Material.model_name.human)
+      # 'ステータスコード422'
+      render :new ,status: :unprocessable_entity
     end
   end
 

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -2,6 +2,8 @@ class Material < ApplicationRecord
   belongs_to :user
   belongs_to :category
 
+  validates :category_id, presence: true
+
   # 各バリデーションを設定
   validates :name, presence: true
   validates :unit_for_product, presence: true

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t('.title') %></h1>
 
 <%# パーシャルを呼び出し、@categoryを渡す %>
-<%= render 'shared/error_messages', resource: @category %>
+<%= render 'shared/error_messages', model: @category %>
 
 <%# form_withに model: @category を渡すことで、新規作成（createアクションへのPOST）と自動的に判断される %>
 <%= form_with model: @category do |f| %>

--- a/app/views/dashboards/_sidebar.html.erb
+++ b/app/views/dashboards/_sidebar.html.erb
@@ -10,7 +10,7 @@
       <%= link_to t('dashboard.menu.category_management'), categories_path, class: "list-group-item list-group-item-action" %>
 
       <%# 原材料管理 %>
-      <%= link_to '原材料管理', materials_path, class: "list-group-item list-group-item-action" %>
+      <%= link_to t('dashboard.menu.material_management'), materials_path, class: "list-group-item list-group-item-action" %>
 
       <hr>
       <%# アカウント設定 %>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -2,41 +2,43 @@
 <%# newとcreateの共通利用。local: true不要で同期通信 %>
 <%= form_with(model: @material) do |f| %>
 
+  <%= render 'shared/error_messages', model: f.object %>
+
   <%# 原材料名 %>
   <div class="mb-3">
   <%# <input>要素に適切な縦の間隔（マージン）を設定%>
-    <%= f.label :name, "名前", class: "form-label" %>
+    <%= f.label :name, class: "form-label" %>
     <%= f.text_field :name, class: "form-control" %>
   </div>
 
   <%# 商品単位 %>
   <div class="mb-3">
-    <%= f.label :unit_for_product, "商品での単位", class: "form-label" %>
+    <%= f.label :unit_for_product, class: "form-label" %>
     <%= f.text_field :unit_for_product, class: "form-control" %>
   </div>
 
   <%# 商品単位あたりの重量 %>
   <div class="mb-3">
-    <%= f.label :unit_weight_for_product, "商品単位あたりの重さ", class: "form-label" %>
+    <%= f.label :unit_weight_for_product, class: "form-label" %>
     <%# 'step: :any'でスピナー対応%>
     <%= f.number_field :unit_weight_for_product, step: :any, class: "form-control" %>
   </div>
 
   <%# 発注単位 %>
   <div class="mb-3">
-    <%= f.label :unit_for_order, "発注単位", class: "form-label" %>
+    <%= f.label :unit_for_order, class: "form-label" %>
     <%= f.text_field :unit_for_order, class: "form-control" %>
   </div>
 
   <%# 発注単位あたりの重量 %>
   <div class="mb-3">
-    <%= f.label :unit_weight_for_order, "発注単位あたりの重さ", class: "form-label" %>
+    <%= f.label :unit_weight_for_order, class: "form-label" %>
     <%= f.number_field :unit_weight_for_order, step: :any, class: "form-control" %>
   </div>
 
   <%# カテゴリー%>
   <div class="mb-3">
-    <%= f.label :category_id, "カテゴリー", class: "form-label" %>
+    <%= f.label :category_id, class: "form-label" %>
     <%# カテゴリーデータを使用してプルダウンメニュー(<select>)を生成 %>
     <%= f.collection_select :category_id, Category.all, :id, :name, { prompt: "選択してください" }, class: "form-select" %>
   </div>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -45,7 +45,7 @@
 
   <div class="actions mt-4">
   <%# <button>の生成$ %>
-  <%= f.submit "登録", class: "btn btn-success" %>
+  <%= f.submit t('helpers.submit.create'), class: "btn btn-success" %>
   <%# ボタンは練習で色付け %>
-  <%= link_to '一覧へ戻る', materials_path, class: "btn btn-outline-secondary" %>
+  <%= link_to t('helpers.link.back'), materials_path, class: "btn btn-outline-secondary" %>
 <% end %>

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -1,20 +1,20 @@
-<h2>原材料管理</h2>
+<h2><%= t('.title') %></h2>
 
 <div class= "d-flex justify-content-end mb-3">
-  <%= link_to '新規原材料を追加', new_material_path, class: 'btn btn-primary' %>
+  <%= link_to t('helpers.link.new', resource: Material.model_name.human), new_material_path, class: 'btn btn-primary' %>
 </div>
 
 <table class ="table mt-4">
 <%# 後でカテゴリー別で検索して表示する%>
   <thead class= "table-light">
-    <tr>
-      <th>カテゴリー</th>
-      <th>原材料名</th>
-      <th>商品単位</th>
-      <th>重量（商品単位）</th>
-      <th>発注単位</th>
-      <th>重量（発注単位）</th>
-      <th>操作</th>
+    <tr><%# モデルの時に使用できるRailsヘルパー %>
+      <th><%= Material.human_attribute_name(:category_id) %></th>
+      <th><%= Material.human_attribute_name(:name) %></th>
+      <th><%= Material.human_attribute_name(:unit_for_product) %></th>
+      <th><%= Material.human_attribute_name(:unit_weight_for_product) %></th>
+      <th><%= Material.human_attribute_name(:unit_for_order) %></th>
+      <th><%= Material.human_attribute_name(:unit_weight_for_order) %></th>
+      <th><%= t('helpers.action') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -1,7 +1,7 @@
 
 <%# flexコンテナの子要素を左右を均等にして上下も中央揃えにする %>
 <div class="d-flex justify-content-between al">
-  <h2>新規原材料の登録</h2>
+  <h2><%= t('materials.new.title') %></h2>
 </div>
 <%# 'card'で丸枠%>
 <div class="card p-4 shadow-sm">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,19 +1,14 @@
-<%# エラーを保持しているモデルオブジェクト %>
-<% if resource.errors.any? %>
-  <%# Bootstrapを使用 %>
+<%# resource -> model に変更 %>
+<% if model.errors.any? %>
   <div id="error_explanation" class="alert alert-danger" role="alert">
-
-    <%# I18n化: エラー数とモデル名を動的に表示 %>
-    <h2>
+    <h4 class="alert-heading">
       <%= t('errors.messages.not_saved',
-            count: resource.errors.count,
-            # モデル名をI18nで取得
-            resource: resource.class.model_name.human)
+            count: model.errors.count,
+            resource: model.class.model_name.human)
       %>
-    </h2>
-
+    </h4>
     <ul class="mb-0">
-      <% resource.errors.full_messages.each do |message| %>
+      <% model.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,11 +5,22 @@ ja:
 
   controllers:
     create:
-      success: "%{resource}を作成しました。"
+      success: "%{resource}を作成しました"
+      failure: "%{resource}の作成に失敗しました"
     update:
-      success: "%{resource}を更新しました。"
+      success: "%{resource}を更新しました"
+      failure: "%{resource}の更新に失敗しました"
     destroy:
-      success: "%{resource}を削除しました。"
+      success: "%{resource}を削除しました"
+
+  dashboard:
+    menu:
+      title: "メニュー"
+      dashboard: "ダッシュボード"
+      category_management: "カテゴリー管理"
+      dashboard.menu.material_management: "原材料管理"
+      account_settings: "アカウント設定"
+    welcome_message: "ようこそ！ %{name} さんのダッシュボード"
 
   categories:
     new:
@@ -19,13 +30,12 @@ ja:
     index:
       title: "カテゴリー一覧"
 
-  dashboard: # 新規追加
-    menu:
-      title: "メニュー"
-      dashboard: "ダッシュボード"
-      category_management: "カテゴリー管理"
-      account_settings: "アカウント設定"
-    welcome_message: "ようこそ！ %{name} さんのダッシュボード"
+  materials:
+    new:
+      title: "新規原材料登録"
+    index:
+      title: "原材料一覧"
+
 
   helpers:
     submit:
@@ -51,8 +61,10 @@ ja:
 
   errors:
     messages:
-      not_saved: "以下の %{count} 件のエラーにより、%{resource} を保存できませんでした。"
+      not_saved: "以下の %{count} 件のエラーにより、%{resource} を保存できませんでした"
       blank: "を入力してください"
+      not_a_number: "は数値で入力してください"
+      greater_than: "%{count} より大きい値を入力してください"
       too_short:
         one: "%{count} 文字以上で入力してください"
         other: "%{count} 文字以上で入力してください"
@@ -67,17 +79,17 @@ ja:
       new:
         sign_in: "ログイン"
         submit: "ログイン"
-      signed_in: "ログインしました。"
-      signed_out: "ログアウトしました。"
+      signed_in: "ログインしました"
+      signed_out: "ログアウトしました"
       sign_out: "ログアウト"
 
     confirmations:
-      confirmed: "アカウントを認証しました。"
+      confirmed: "アカウントを認証しました"
 
     failure:
-      unauthenticated: "アカウント登録もしくはログインが必要です。"
-      invalid: "メールアドレスまたはパスワードが違います。"
-      not_found_in_database: "メールアドレスまたはパスワードが違います。"
+      unauthenticated: "アカウント登録もしくはログインが必要です"
+      invalid: "メールアドレスまたはパスワードが違います"
+      not_found_in_database: "メールアドレスまたはパスワードが違います"
 
     registrations:
       new:
@@ -85,11 +97,11 @@ ja:
       edit:
         title: "アカウント編集"
         cancel_my_account: "アカウンを削除する"
-      signed_up: "アカウント登録が完了しました。"
-      pending_reconfirmation: "現在、%{unconfirmed_email} の確認待ちです。"
+      signed_up: "アカウント登録が完了しました"
+      pending_reconfirmation: "現在、%{unconfirmed_email} の確認待ちです"
       user:
-        updated: "アカウント情報が正常に更新されました。"
-        destroyed: "アカウントを削除しました。"
+        updated: "アカウント情報が正常に更新されました"
+        destroyed: "アカウントを削除しました"
 
     shared:
       minimum_password_length: "(%{count}文字以上)"
@@ -98,8 +110,8 @@ ja:
         forgot_your_password: "パスワードを忘れた方"
 
     passwords:
-      send_instructions: "パスワード再設定のメールを送信しました。"
-      updated: "パスワードを変更しました。"
+      send_instructions: "パスワード再設定のメールを送信しました"
+      updated: "パスワードを変更しました"
       new:
         forgot_your_password: "パスワードを忘れた方"
         submit: "パスワード再設定のメールを送信"
@@ -112,9 +124,9 @@ ja:
         subject: "【寿司管理システム】パスワード再設定のご案内"
         greeting: "こんにちは %{name} さん！"
         action: "パスワードの変更"
-        instruction_1: "パスワードをリセットするには、以下のリンクをクリックしてください。"
-        instruction_2: "このメールに心当たりがない場合は、無視して構いません。"
-        instruction_3: "パスワードは、上記のリンクをクリックして新しいパスワードを作成するまで変更されません。"
+        instruction_1: "パスワードをリセットするには、以下のリンクをクリックしてください"
+        instruction_2: "このメールに心当たりがない場合は、無視して構いません"
+        instruction_3: "パスワードは、上記のリンクをクリックして新しいパスワードを作成するまで変更されません"
 
   activerecord:
     errors:
@@ -144,3 +156,12 @@ ja:
           material: "原材料"
           product: "商品"
           plan: "計画"
+
+      material: # 原材料の属性定義を追加
+        name: "原材料名"
+        unit_for_product: "商品単位"
+        unit_weight_for_product: "重量（商品単位）"
+        unit_for_order: "発注単位"
+        unit_weight_for_order: "重量（発注単位）"
+        category_id: "カテゴリー"
+        category: "カテゴリー"

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
-    "build:css:compile": "bunx sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
-    "build:css:prefix": "bunx postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
-    "build:css": "bun run build:css:compile && bun run build:css:prefix",
-    "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"bun run build:css\""
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
+    "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
+    "build:css": "yarn build:css:compile && yarn build:css:prefix",
+    "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",


### PR DESCRIPTION
## 概要
原材料管理機能全体でI18n対応を完了させ、ユーザーへのエラーメッセージと操作完了時のフラッシュメッセージ表示ロジックを共通化・整理しました。

## 変更内容### Controller
- 'app/controllers/materials_controller.rb' でCRUDアクションで直書きされていた日本語のフラッシュメッセージを、すべて t('controllers.***') を用いたI18nキーに変更
- 'app/controllers/materials_controller.rb'で バリデーションエラー時に flash.now[:alert] を設定し、status: :unprocessable_entity を返すように修正

### View
-' app/views/materials/_form.html.erb' フォームのバリデーションエラー表示のため、共通パーシャル render 'shared/error_messages', model: f.object を組み込み
- 'app/views/materials/*'で、タイトル、テーブルヘッダー、ボタン、リンクのテキストを I18n キー（t('materials.***') や t('helpers.***'), Material.human_attribute_name）に置き換え
- 'app/views/dashboards/_sidebar.html.erb'で「原材料管理」メニューを追加し、I18n化

### Config/Locale
- 'config/locales/ja.yml;
  - controllers ブロックに CRUD の success/failure メッセージキーを追加
  - materials ブロックにビュータイトル関連のキーを追加
  - activerecord.attributes.material に原材料モデルの属性名（例: name, unit_for_product）を定義

## 動作確認
### 新規作成：
- [x] 成功時、I18n化されたフラッシュメッセージが表示されること
- [x] バリデーション失敗時、フォーム上部にI18n化されたエラーメッセージが表示され、flash.now の失敗メッセージが表示されること
### 編集：
- [x] 成功/失敗時、新規作成と同様にI18n対応したメッセージが正しく表示されること
### 削除：
- [x] helpers.confirm.destroy のキーを使った確認ダイアログが表示され、削除成功後にフラッシュメッセージが表示されること
### 全てのビュー：
- [x] タイトル、ラベル、ボタンテキストが日本語で正しく表示されていること

### レビューポイント
- [ ] 権限制御の実装	現状維持（権限制御の変更なし）
- [ ] セキュリティ面の確認	params はController内で適切に許可しており問題ありません
- [ ] ja.yml の定義（controllers, activerecord.attributes.material）が適切か