### PR TITLE
Refactor/title tag i18n

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+
+  # レイアウトを動的に切り替える設定を移植
+  layout :layout_by_resource
+
   # Devise利用時のストロングパラメータを設定するためのフック
   before_action :configure_permitted_parameters, if: :devise_controller?
 
@@ -18,4 +22,19 @@ class ApplicationController < ActionController::Base
     # 認証済みユーザーのルートパスへ遷移
     authenticated_root_path
   end
+
+  # 認証状態に応じてレイアウトを切り替えるメソッド
+  def layout_by_resource
+    # Deviseのコントローラー（ログイン、新規登録など）であり、かつ未認証の場合
+    if devise_controller? && !user_signed_in?
+      'application'
+    # 認証済みの画面の場合
+    elsif user_signed_in?
+      'authenticated_layout'
+    # その他（Devise以外のコントローラーなど）の場合
+    else
+      'application'
+    end
+  end
+
 end

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,6 +1,4 @@
 class AuthenticatedController < ApplicationController
   # 認証必須のチェックを移植して
   before_action :authenticate_user!
-
-  layout 'authenticated_layout'
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,8 +15,9 @@ class CategoriesController < AuthenticatedController
 
     # メッセージ追加: 新規作成成功
     if @category.save
-      redirect_to categories_path, notice: t('controllers.create.success', resource: Category.model_name.human)
+      redirect_to categories_path, notice: t('flash_massages.create.success', resource: Category.model_name.human)
     else
+      flash.now[:alert] = t('flash_messages.create.failure', resource: Category.model_name.human)
       render :new
     end
   end
@@ -31,9 +32,10 @@ class CategoriesController < AuthenticatedController
 
     if @category.update(category_params)
       # 更新成功したら一覧画面へリダイレクト
-      redirect_to categories_path, notice: t('controllers.update.success', resource: Category.model_name.human)
+      redirect_to categories_path, notice: t('flash_massages.update.success', resource: Category.model_name.human)
     else
       # 更新失敗したら編集画面を再表示
+      flash.now[:alert] = t('flash_messages.update.failure', resource: Category.model_name.human)
       render :edit
     end
   end
@@ -44,7 +46,7 @@ class CategoriesController < AuthenticatedController
     # レコードを削除
     @category.destroy
     # 削除成功後、一覧画面へリダイレクト
-      redirect_to categories_path, notice: t('controllers.destroy.success', resource: Category.model_name.human)
+      redirect_to categories_path, notice: t('flash_massages.destroy.success', resource: Category.model_name.human)
   end
 
 

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -17,11 +17,11 @@ class MaterialsController <  AuthenticatedController
 
     if @material.save
       # 'モデル名を参照する'
-      flash[:notice] = t('controllers.create.success', resource: Material.model_name.human)
+      flash[:notice] = t('flash_massages.create.success', resource: Material.model_name.human)
       redirect_to materials_path
     else
       # 'render'で再表示
-      flash.now[:alert] = t('controllers.create.failure', resource: Material.model_name.human)
+      flash.now[:alert] = t('flash_massages.create.failure', resource: Material.model_name.human)
       # 'ステータスコード422'
       render :new ,status: :unprocessable_entity
     end

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,7 +1,8 @@
+<%= content_for :page_title, t('categories.edit.title') %>
 <h1><%= t('.title') %></h1>
 
 <%# エラーパーシャルを呼び出し、@categoryを渡す %>
-<%= render 'shared/error_messages', resource: @category %>
+<%= render 'shared/error_messages', model: @category %>
 
 <%# form_withに @category を渡すことで、自動的に update アクションへ送信 %>
 <%= form_with model: @category do |f| %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :page_title, t('categories.index.title') %>
 <h1><%= t('.title') %></h1>
 
 <table class="table">

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :page_title, t('categories.new.title') %>
 <h1><%= t('.title') %></h1>
 
 <%# パーシャルを呼び出し、@categoryを渡す %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,0 +1,3 @@
+<%= content_for :page_title, t('dashboard.menu.dashboard') %>
+
+<h1><%= t('dashboard.welcome_message', name: current_user.name) %></h1>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render 'layouts/auth_card_frame', title: t('devise.system_title') do %>
+<% content_for :page_title, t('devise.passwords.edit.title') %>
+<%= render layout: 'devise/shared/auth_card_frame' do %>
 
   <h2 class="text-center mb-4"><%= t("devise.passwords.edit.title") %></h2>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -30,7 +30,4 @@
       <%= f.submit t("devise.passwords.edit.submit"), class: "btn btn-primary" %>
     </div>
   <% end %>
-
-  <%= render "devise/shared/links" %>
-
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,7 +2,7 @@
 <%= render layout: 'devise/shared/auth_card_frame' do %>
 
   <%# ページ固有のH2タイトルをI18n化して配置 %>
-  <h2 class="text-center mb-3"><%= t('devise.passwords.new.forgot_your_password') %></h2>
+  <h2 class="text-center mb-3"><%= t('devise.passwords.new.title') %></h2>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,8 @@
+<%= content_for :page_title, t('devise.passwords.new.title') %>
 <%= render layout: 'devise/shared/auth_card_frame' do %>
 
   <%# ページ固有のH2タイトルをI18n化して配置 %>
-  <h2 class="text-center mb-3"><%= t(".forgot_your_password") %></h2>
+  <h2 class="text-center mb-3"><%= t('devise.passwords.new.forgot_your_password') %></h2>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :page_title, t('devise.registrations.edit.title') %>
 <h2><%= t(".title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_title, t('devise.registrations.new.title') %>
 <%= render layout: 'devise/shared/auth_card_frame' do %>
 
     <%= render "devise/shared/tabs" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <div class="d-grid gap-2">
-      <%= f.submit t("devise.registrations.new.submit"), class: "btn btn-success" %>
+      <%= f.submit t('helpers.submit.create'), class: "btn btn-success" %>
     </div>
   <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+
+<% content_for :page_title, t('devise.sessions.new.title') %>
 <%= render layout: 'devise/shared/auth_card_frame' do %>
 
   <%= render "devise/shared/tabs" %>

--- a/app/views/devise/shared/_auth_card_frame.html.erb
+++ b/app/views/devise/shared/_auth_card_frame.html.erb
@@ -1,7 +1,7 @@
 <div class="row justify-content-center">
   <div class="col-lg-6 col-md-8">
     <div class="card p-4">
-      <h1 class="card-title text-center mb-4"><%= t('devise.system_title') %></h1>
+      <h1 class="card-title text-center mb-4"><%= t('application_name') %></h1>
       <%# tabsパーシャルが存在する場合、ここで直接呼び出す %>
       <%= yield %> <%# フォーム本体を出力 %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <%# タイトルタグのロジックを追加 %>
+    <title>
+      <%= content_for?(:page_title) ? "#{yield(:page_title)} | #{t('application_name')}" : t('application_name') %>
+    </title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%# Bootstrap CSSをCDNで読み込み %>

--- a/app/views/layouts/authenticated_layout.html.erb
+++ b/app/views/layouts/authenticated_layout.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= t('devise.system_title') %></title>
+    <title>
+      <%= content_for?(:page_title) ? "#{yield(:page_title)} | #{t('application_name')}" : t('application_name') %>
+    </title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%# Bootstrap CSSをCDNで読み込み %>

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :page_title, t('materials.index.title') %>
 <h2><%= t('.title') %></h2>
 
 <div class= "d-flex justify-content-end mb-3">

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -1,4 +1,4 @@
-
+<%= content_for :page_title, t('materials.new.title') %>
 <%# flexコンテナの子要素を左右を均等にして上下も中央揃えにする %>
 <div class="d-flex justify-content-between al">
   <h2><%= t('materials.new.title') %></h2>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,7 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
 
-  controllers:
+  flash_massagers:
     create:
       success: "%{resource}を作成しました"
       failure: "%{resource}の作成に失敗しました"
@@ -96,7 +96,6 @@ ja:
     registrations:
       new:
         title: "新規登録"
-        submit: "登録"
       edit:
         title: "アカウント編集"
         cancel_my_account: "アカウンを削除する"
@@ -117,7 +116,6 @@ ja:
       updated: "パスワードを変更しました"
       new:
         title: "パスワードを忘れた方"
-        forgot_your_password: "パスワードを忘れた方"
         submit: "パスワード再設定のメールを送信"
       edit:
         title: "パスワード変更"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,6 @@
 ja:
+  application_name: "寿司管理システム"
+
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
@@ -18,7 +20,7 @@ ja:
       title: "メニュー"
       dashboard: "ダッシュボード"
       category_management: "カテゴリー管理"
-      dashboard.menu.material_management: "原材料管理"
+      material_management: "原材料管理"
       account_settings: "アカウント設定"
     welcome_message: "ようこそ！ %{name} さんのダッシュボード"
 
@@ -74,9 +76,9 @@ ja:
       not_found: "が見つかりません"
 
   devise:
-    system_title: "寿司管理システム"
     sessions:
       new:
+        title: "ログイン"
         sign_in: "ログイン"
         submit: "ログイン"
       signed_in: "ログインしました"
@@ -93,6 +95,7 @@ ja:
 
     registrations:
       new:
+        title: "新規登録"
         submit: "登録"
       edit:
         title: "アカウント編集"
@@ -113,11 +116,12 @@ ja:
       send_instructions: "パスワード再設定のメールを送信しました"
       updated: "パスワードを変更しました"
       new:
+        title: "パスワードを忘れた方"
         forgot_your_password: "パスワードを忘れた方"
         submit: "パスワード再設定のメールを送信"
       edit:
-        title: "パスワードの変更"
-        submit: "パスワードを変更"
+        title: "パスワード変更"
+        submit: "パスワード変更"
 
     mailer:
       reset_password_instructions:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,7 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
 
-  flash_massagers:
+  flash_massages:
     create:
       success: "%{resource}を作成しました"
       failure: "%{resource}の作成に失敗しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,7 +26,7 @@ ja:
 
   categories:
     new:
-      title: "新規カテゴリー登録"
+      title: "カテゴリー登録"
     edit:
       title: "カテゴリー編集"
     index:
@@ -34,7 +34,7 @@ ja:
 
   materials:
     new:
-      title: "新規原材料登録"
+      title: "原材料登録"
     index:
       title: "原材料一覧"
 


### PR DESCRIPTION
## 概要
I18n キー定義における冗長性（ネストの深さや重複）を解消し、フォームボタンのテキストを汎用的な helpers セクションに統合しました。
Devise 関連画面を含む、全ての管理画面のブラウザタイトル（<title>タグ）を設定しました。

## 変更内容
### Controller:
- フラッシュメッセージを翻訳する階層のi18nの命名をcontrollersからflash_massgesに変更

## View
### 全管理画面（カテゴリー、原材料、ダッシュボード）:
- 各 index.html.erb, new.html.erb, edit.html.erb ファイルに、content_for :page_title, t('統合キー') を追加し、ブラウザタイトルを設定
- 画面見出し (<h1>) も同じ統合キーを参照するように修正

### app/views/devise/registrations/new.html.erb 他:
- フォーム送信ボタンの I18n キー参照を、Devise 固有のキー（例: t(".submit")）から、t('helpers.submit.create') などの汎用キーに変更

## 動作確認
### 全画面タイトルタグ	
- [x] ダッシュボード、カテゴリー、原材料、Devise 関連の全ての画面で、タブに正しい日本語タイトルが表示されること
### I18n キー統合	
- [x] Devise 新規登録、原材料新規登録画面で、フォームボタンが helpers.submit.create を参照し、「登録」と表示されること
- [x] 原材料新規登録画面で、フォームのラベルが activerecord.attributes から取得され、日本語で表示されること

## レビューポイント
- [ ] config/locales/ja.yml における、タイトルキーのネスト解消と helpers への統合が、他セクションに影響を与えていないか
- [ ] 各管理画面の new/edit ビューで、タイトルタグの設定漏れがないか
- [ ] ja.yml の統合されたキーがすべての該当ビューで正しく参照されているか







