### PR TITLE
Featuer/material create update

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,9 +1,11 @@
 class MaterialsController <  AuthenticatedController
+  before_action :set_material, only: [:show]
   def index
     @materials = Material.all
   end
 
   def show
+    # before_actionで完結
   end
 
   def new
@@ -28,6 +30,7 @@ class MaterialsController <  AuthenticatedController
   end
 
   def edit
+
   end
 
   def update
@@ -46,5 +49,10 @@ class MaterialsController <  AuthenticatedController
     :unit_weight_for_order,
     :category_id
   )
+  end
+
+  # @materialの検索（ログインユーザーのもの）
+  def set_material
+    @material = current_user.materials.find(params[:id])
   end
 end

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -28,6 +28,7 @@
       <td><%= number_with_precision(material.unit_weight_for_product, precision: 3) %></td>
       <td><%= material.unit_for_order %></td>
       <td><%= number_with_precision(material.unit_weight_for_order, precision: 3) %></td>
+      <td><%= link_to"詳細", material_path(material)%></td>
     <% end %>
   </tbody>
 </table>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -1,2 +1,27 @@
-<h1>Materials#show</h1>
-<p>Find me in app/views/materials/show.html.erb</p>
+<%# タイトルタグ %>
+<div class="mb-4">
+  <h2>原材料詳細:<%= @material.name %></h2>
+</div>
+
+<dt class="col-sm-3">原材料名</dt>
+    <dd class="col-sm-9"><%= @material.name %></dd>
+
+    <dt class="col-sm-3">カテゴリー</dt>
+    <dd class="col-sm-9"><%= @material.category.name %></dd>
+
+    <dt class="col-sm-3">商品単位</dt>
+    <dd class="col-sm-9"><%= @material.unit_for_product %></dd>
+
+    <dt class="col-sm-3">商品単位重量</dt>
+    <%# 小数点以下3桁まで表示（number_with_precision は標準ヘルパーとして利用） %>
+    <dd class="col-sm-9"><%= number_with_precision(@material.unit_weight_for_product, precision: 3) %></dd>
+
+    <dt class="col-sm-3">発注単位</dt>
+    <dd class="col-sm-9"><%= @material.unit_for_order %></dd>
+  </dl>
+
+  <div class="mt-4">
+    <%= link_to "一覧へ戻る", materials_path, class: 'btn btn-secondary' %>
+  <div>
+</div>
+

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -1,28 +1,43 @@
 <%# タイトルタグ %>
 <%= content_for :page_title, t('materials.show.title') %>
 <div class="mb-4">
-  <h2>原材料詳細:<%= @material.name %></h2>
+  <h2>
+    <%= @material.name %> - <%= t('.title') %>
+    </h2>
 </div>
 
-<dt class="col-sm-3">原材料名</dt>
+<div class="card p-4 shadow-sm">
+  <dl class="row">
+    <%#  human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:name) %></dt>
     <dd class="col-sm-9"><%= @material.name %></dd>
 
-    <dt class="col-sm-3">カテゴリー</dt>
+    <%#  human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:category_id) %></dt>
     <dd class="col-sm-9"><%= @material.category.name %></dd>
 
-    <dt class="col-sm-3">商品単位</dt>
+    <%# human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_for_product) %></dt>
     <dd class="col-sm-9"><%= @material.unit_for_product %></dd>
 
-    <dt class="col-sm-3">商品単位重量</dt>
+    <%#  human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_weight_for_product) %></dt>
     <%# 小数点以下3桁まで表示（number_with_precision は標準ヘルパーとして利用） %>
     <dd class="col-sm-9"><%= number_with_precision(@material.unit_weight_for_product, precision: 3) %></dd>
 
-    <dt class="col-sm-3">発注単位</dt>
+    <%# human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_for_order) %></dt>
     <dd class="col-sm-9"><%= @material.unit_for_order %></dd>
+
+    <%# human_attribute_nameでI18n化 %>
+    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_weight_for_order) %></dt>
+    <%# 小数点以下3桁まで表示 %>
+    <dd class="col-sm-9"><%= number_with_precision(@material.unit_weight_for_order, precision: 3) %></dd>
   </dl>
+</div>
 
   <div class="mt-4">
-    <%= link_to "一覧へ戻る", materials_path, class: 'btn btn-secondary' %>
+    <%= link_to t('helpers.link.back'), materials_path, class: 'btn btn-secondary' %>
   <div>
 </div>
 

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -1,43 +1,67 @@
-<%# タイトルタグ %>
+<%# ページタイトル %>
 <%= content_for :page_title, t('materials.show.title') %>
+
 <div class="mb-4">
   <h2>
-    <%= @material.name %> - <%= t('.title') %>
-    </h2>
+    <%= @material.name %> - <%= t('materials.show.title') %>
+  </h2>
+</div>
+<%# カード風のデザイン %>
+<div class="card p-4 mb-4">
+<%# 横並びの土台  %>
+  <div class="row">
+    <%# 原材料名、横幅50% %>
+    <div class="col-6 mb-3">
+    　<%# 太字 %>
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:name) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= @material.name %></p>
+      </div>
+    </div>
+
+    <%# カテゴリー項目 %>
+    <div class="col-6 mb-3">
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:category_id) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= @material.category.name %></p>
+      </div>
+    </div>
+
+    <%# 商品単位 %>
+    <div class="col-6 mb-3">
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:unit_for_product) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= @material.unit_for_product %></p>
+      </div>
+    </div>
+
+    <%# 発注単位 %>
+    <div class="col-6 mb-3">
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:unit_for_order) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= @material.unit_for_order %></p>
+      </div>
+    </div>
+
+    <%# 重量（商品単位） %>
+    <div class="col-6 mb-3">
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:unit_weight_for_product) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= number_with_precision(@material.unit_weight_for_product, precision: 3) %></p>
+      </div>
+    </div>
+
+    <%# 重量（発注単位） %>
+    <div class="col-6 mb-3">
+      <p class="mb-2 fw-bold"><%= Material.human_attribute_name(:unit_weight_for_order) %></p>
+      <div class="border p-3 rounded">
+        <p class="mb-0"><%= number_with_precision(@material.unit_weight_for_order, precision: 3) %></p>
+      </div>
+    </div>
+  </div>
 </div>
 
-<div class="card p-4 shadow-sm">
-  <dl class="row">
-    <%#  human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:name) %></dt>
-    <dd class="col-sm-9"><%= @material.name %></dd>
-
-    <%#  human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:category_id) %></dt>
-    <dd class="col-sm-9"><%= @material.category.name %></dd>
-
-    <%# human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_for_product) %></dt>
-    <dd class="col-sm-9"><%= @material.unit_for_product %></dd>
-
-    <%#  human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_weight_for_product) %></dt>
-    <%# 小数点以下3桁まで表示（number_with_precision は標準ヘルパーとして利用） %>
-    <dd class="col-sm-9"><%= number_with_precision(@material.unit_weight_for_product, precision: 3) %></dd>
-
-    <%# human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_for_order) %></dt>
-    <dd class="col-sm-9"><%= @material.unit_for_order %></dd>
-
-    <%# human_attribute_nameでI18n化 %>
-    <dt class="col-sm-3"><%= Material.human_attribute_name(:unit_weight_for_order) %></dt>
-    <%# 小数点以下3桁まで表示 %>
-    <dd class="col-sm-9"><%= number_with_precision(@material.unit_weight_for_order, precision: 3) %></dd>
-  </dl>
+<%# アクションボタン %>
+<div class="mt-4">
+  <%= link_to t('helpers.link.back'), materials_path, class: 'btn btn-secondary' %>
 </div>
-
-  <div class="mt-4">
-    <%= link_to t('helpers.link.back'), materials_path, class: 'btn btn-secondary' %>
-  <div>
-</div>
-

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -1,4 +1,5 @@
 <%# タイトルタグ %>
+<%= content_for :page_title, t('materials.show.title') %>
 <div class="mb-4">
   <h2>原材料詳細:<%= @material.name %></h2>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,6 +37,8 @@ ja:
       title: "原材料登録"
     index:
       title: "原材料一覧"
+    show:
+      title: "原材料詳細"
 
 
   helpers:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,7 +40,6 @@ ja:
     show:
       title: "原材料詳細"
 
-
   helpers:
     submit:
       create: "登録"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,4 @@
 Rails.application.routes.draw do
-  get "materials/index"
-  get "materials/show"
-  get "materials/new"
-  get "materials/create"
-  get "materials/edit"
-  get "materials/update"
-  get "materials/destroy"
 
   # controllersオプションを追加し、RegistrationsControllerを指定
   devise_for :users, controllers: {


### PR DESCRIPTION
## 概要
原材料詳細画面（materials#show）の表示機能の実装を完了しました。レイアウトを2カラムの均等グリッドデザインに最適化しました。
また、コントローラーにセキュリティのための権限制御を実装済みです。次のステップに向けた「編集」ボタンを追加しています。

## 変更内容
### Controller
app/controllers/materials_controller.rb の変更:
- set_material メソッドの追加: current_user.materials.find(params[:id]) を使用し、ログインユーザーが所有する原材料のみを検索対象とする権限制御を実装
- before_action :set_material, only: [:show, :edit, :update, :destroy] を設定し、show アクションに権限制御と共通のデータ取得処理を適用

## View
app/views/materials/show.html.erb の変更:
- すべての属性（名称、カテゴリ、各種単位と重量）を、col-md-6 による2カラムの均等グリッドで配置
- 各属性をカード（枠線）デザインで囲み、ラベルと値を縦積みにする表示形式を採用

## 動作確認
### 原材料詳細画面表示
- 2カラム均等配置:	 
  -[x] すべての属性が2カラムで表示されていることを確認。
- 18n適用:	
  - [x] 項目名とボタンテキストが正しくI18n化されていることを確認
- 権限制御:
  - [x] set_materialにより、存在しないIDや他ユーザーのIDにアクセスした場合にエラーとなることを確認
  - [x]「編集」ボタン edit_material_pathへ正しく遷移できることを確認

## レビューポイント
### 権限制御の実装:	
- [ ] set_materialでのデータ絞り込みが意図通りに動作していることを確認してください
- [ ] Viewで表示するデータに意図しないHTMLやスクリプトが含まれていないか確認してください
- [ ] 画面幅の狭い環境でレイアウトが崩れないか確認してください。
