### PR TITLE
refactor: カテゴリ管理のビュー共通化を完了し、コントローラーを最適化

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,7 +15,7 @@ class CategoriesController < AuthenticatedController
 
     # メッセージ追加: 新規作成成功
     if @category.save
-      redirect_to categories_path, notice: t('flash_massages.create.success', resource: Category.model_name.human, name: @category.name)
+      redirect_to categories_path, notice: t('flash_messages.create.success', resource: Category.model_name.human, name: @category.name)
     else
       flash.now[:alert] = t('flash_messages.create.failure', resource: Category.model_name.human)
       render :new
@@ -32,7 +32,7 @@ class CategoriesController < AuthenticatedController
 
     if @category.update(category_params)
       # 更新成功したら一覧画面へリダイレクト
-      redirect_to categories_path, notice: t('flash_massages.update.success', resource: Category.model_name.human, name: @category.name)
+      redirect_to categories_path, notice: t('flash_messages.update.success', resource: Category.model_name.human, name: @category.name)
     else
       # 更新失敗したら編集画面を再表示
       flash.now[:alert] = t('flash_messages.update.failure', resource: Category.model_name.human)
@@ -46,7 +46,7 @@ class CategoriesController < AuthenticatedController
     # レコードを削除
     @category.destroy
     # 削除成功後、一覧画面へリダイレクト
-      redirect_to categories_url, notice: t('flash_massages.destroy.success', resource: Category.model_name.human, name: @category.name)
+      redirect_to categories_url, notice: t('flash_messages.destroy.success', resource: Category.model_name.human, name: @category.name)
   end
 
 

--- a/app/views/categories/_category_fields.html.erb
+++ b/app/views/categories/_category_fields.html.erb
@@ -1,0 +1,13 @@
+<%# 1. カテゴリ名 (name) %>
+<div class="mb-3">
+  <%= f.label :name, class: "form-label" %>
+  <%= f.text_field :name, class: "form-control" %>
+</div>
+
+<%# 2. カテゴリ種別 (category_type) %>
+<div class="mb-3">
+  <%= f.label :category_type, class: "form-label" %>
+
+  <%# 選択肢の表示を整えるため humanize を使用し、Bootstrapのフォームクラスを適用 %>
+  <%= f.select :category_type, Category.category_types.keys.map { |k| [k.humanize, k] }, {}, class: "form-select" %>
+</div>

--- a/app/views/categories/_category_table.html.erb
+++ b/app/views/categories/_category_table.html.erb
@@ -1,0 +1,28 @@
+<%# categories: ローカル変数として渡されたカテゴリのコレクション %>
+<table class="table mt-4">
+  <thead class="table-light">
+    <tr>
+      <th><%= Category.human_attribute_name(:name) %></th>
+      <th><%= Category.human_attribute_name(:category_type) %></th>
+      <th><%= t('helpers.action') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% categories.each do |category| %>
+      <tr>
+        <td><%= category.name %></td>
+        <td><%= category.category_type %></td>
+        <td>
+          <%# 詳細画面がないため、編集と削除アクションを配置 %>
+          <%= link_to t('helpers.link.edit'), edit_category_path(category) %>
+
+          <%= button_to "削除", category_path(category),
+              method: :delete,
+              data: { turbo_confirm: "本当に削除しますか？" },
+              class: "btn btn-danger btn-sm",
+              form: { style: "display: inline-block;" } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,24 +1,12 @@
-<%= content_for :page_title, t('categories.edit.title') %>
-<h1><%= t('.title') %></h1>
+<%# パーシャルでインスタンス変数をcategoryで扱える %>
+<%= render 'shared/form_wrapper',
+    # 1. タイトル設定: materials と完全に同じ I18n パターン
+    title: t('.title', category_name: @category.name),
+    # 2. リソース: materials と同じく @category を渡す
+    resource: @category,
+    # 3. 戻り先: カテゴリには詳細がないため、一覧画面 categories_path に固定
+    back_path: categories_path do |f| %>
 
-<%# エラーパーシャルを呼び出し、@categoryを渡す %>
-<%= render 'shared/error_messages', model: @category %>
-
-<%# form_withに @category を渡すことで、自動的に update アクションへ送信 %>
-<%= form_with model: @category do |f| %>
-
-  <div class="form-group">
-    <%= f.label :name %>
-    <%= f.text_field :name %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :category_type %>
-    <%= f.select :category_type, Category.category_types.keys %>
-  </div %>
-
-  <%= f.submit t("helpers.submit.update") %>
+  <%# Category固有のフォーム項目を挿入 %>
+  <%= render 'category_fields', f: f %>
 <% end %>
-
-<hr>
-<%= link_to t('helpers.link.back'), categories_path %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,33 +1,8 @@
-<%= content_for :page_title, t('categories.index.title') %>
-<h1><%= t('.title') %></h1>
+<%= render 'shared/resource_list',
+    title: t('.title'),
+    new_path: new_category_path,
+    new_resource_name: Category.model_name.human do %>
 
-<table class="table">
-
-    <thead>
-      <tr>
-        <th><%= Category.human_attribute_name(:name) %></th>
-        <th><%= t('helpers.action') %></th>
-      </tr>
-    </thead>
-
-  <tbody>
-    <% @categories.each do |category| %>
-      <tr>
-        <td><%= category.name %></td>
-
-        <td>
-          <%= link_to t('helpers.link.edit'), edit_category_path(category) %>
-
-          <%= button_to "削除", category_path(category),
-    method: :delete,
-    data: { turbo_confirm: "本当に削除しますか？" },
-    class: "btn btn-danger btn-sm",
-    form: { style: "display: inline-block;" } %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<%= link_to t('helpers.link.new', resource: Category.model_name.human), new_category_path, class: "btn btn-primary mt-3" %>
-<%= link_to t('helpers.link.back_to_dashboard'), authenticated_root_path, class: "btn btn-secondary mt-3" %>
+  <%# ローカル変数 categories に @categories の値を渡す %>
+  <%= render 'category_table', categories: @categories %>
+<% end %>


### PR DESCRIPTION
## 概要
カテゴリ管理の全てのCRUDビュー（index, new, edit）を、既存の原材料と同じパターンで共通ラッパーを使用するようにリファクタリングしました。
また、共通化に伴い、CategoriesController の冗長なコードを整理し.フラッシュメッセージの翻訳エラーを解消しました。

## 変更点
### コントローラーの最適化 
- edit, update, destroy アクションで使用されていた重複コードを解消するため、before_action :set_category を導入しました。
- category_params メソッドのコメントと引数を、name と category_type を含む最新の仕様に合わせました。

### フラッシュメッセージのバグ修正
- コントローラー内の t メソッドの呼び出しで発生していたキーのタイポ（flash_massages）を flash_messages に修正しました。

### ビューの共通化と DRY化
- categories/index.html.erb を _resource_list と _category_table を使用するように置換しました。
- categories/new.html.erb と categories/edit.html.erb を _form_wrapper と _category_fields を使用するように置換し、フォームの構造を統一しました。
- カテゴリの仕様に基づき、_category_fields.html.erb には name と category_type のみを含めました。

##  動作確認
###  新規作成・編集・削除機能の確認
  - [x] 新規作成	カテゴリを新規作成し、一覧画面に遷移する。	1. データが正しく保存される。 2. 緑色の成功メッセージが正しく翻訳されて表示される（Translation missingが出ない）。
  - [x] 編集	既存のカテゴリ名を変更し、保存する。	1. データが正しく更新される。 2. 緑色の成功メッセージが正しく翻訳されて表示される。
  - [x] カテゴリを削除する。	1. データがDBから削除される。 2. 緑色の成功メッセージが正しく翻訳されて表示される。
  - [x] nameを空欄にして新規作成または更新を行う。	1. 一覧画面に遷移せず、フォーム画面が再表示される。 2. エラーメッセージパーシャルが正しくエラー内容を表示する。
### ビュー共通化の確認
- [x] 新規作成画面	カテゴリの新規作成画面（/categories/new）を開く。	フォームの外枠、タイトル、送信ボタンが原-- [x] 材料のフォームと同じ共通デザインになっている。
- [x] 編集画面	カテゴリの編集画面（/categories/:id/edit）を開く。	フォームの外枠、タイトル、更新ボタンが原材料の編集フォームと同じ共通デザインになっている。
- [x] 戻るリンク	編集画面や新規作成画面から「戻る」リンクをクリックする。	カテゴリ一覧画面に正しく遷移する。

## レビューポイント
### コントローラーのDRY化と保守性
before_action の適用:
  - [ ] CategoriesController 内で、@category = current_user.categories.find(params[:id]) の重複コードが完全に削除され、before_action :set_category に置き換えられているか。

ストロングパラメータ:
  - [ ] category_params のコメントが、許可している属性（nameとcategory_type）と一致しているか。

I18n キーの統一:
  - [ ] notice: にて、修正後のキー flash_messages がすべてのCRUDアクション（create, update, destroy）で正しく使用されているか。

### ビューの責務の分離 (DRY原則)
categories/index.html.erb:
  - [ ] このファイルに <table> や <tr> などの具体的なHTMLタグが残っておらず、render 'shared/resource_list' の呼び出しのみになっているか。

フォームビュー (new/edit):
- [ ] categories/new.html.erb および categories/edit.html.erb に form_with や h1、送信ボタンのコードが残っておらず、render 'shared/form_wrapper' の呼び出しのみになっているか。

固有パーシャルの品質:
- [ ] category_fields.html.erb に、フォームビルダー f を使った入力フィールドのコード以外（例: form_with、送信ボタン）が含まれていないか。
