### PR TITLE
feat: PaginationConcernでページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-# Rails本体と基盤となる主要Gemのグループ
+# 主要グループ
 
-# Active Model has_secure_passwordを使用する場合に必要 (今回はDeviseを使用するためコメントアウト維持)
+# Active Model has_secure_passwordを使用する場合に必要 (今回はDeviseを使用するためコメントアウト)
 # gem "bcrypt", "~> 3.1.7"
 
 # キャッシュを通じて起動時間を短縮（config/boot.rbで必要）
@@ -26,6 +26,12 @@ gem "jsbundling-rails"
 
 # DockerコンテナとしてデプロイするためのGem [https://kamal-deploy.org]
 gem "kamal", require: false
+
+# ページネーション機能を提供するGem [https://github.com/kaminari/kaminari]
+gem 'kaminari', '1.2.2'
+
+# KaminariのBootstrap5対応ビューテンプレート [https://github.com/bootstrap-ruby/bootstrap_form]
+gem 'bootstrap5-kaminari-views'
 
 # データベースとしてPostgreSQLを使用するためのGem
 gem "pg", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     brakeman (7.1.0)
       racc
     builder (3.3.0)
@@ -158,6 +161,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -439,6 +454,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bootstrap5-kaminari-views
   brakeman
   capybara
   cssbundling-rails
@@ -448,6 +464,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  kaminari (= 1.2.2)
   mailcatcher
   pg (~> 1.1)
   propshaft

--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -1,0 +1,94 @@
+# class BaseResourceController < AuthenticatedController
+#   # 継承先のコントローラーが使用するリソース名（例: :material等のシンボル）を動的に決定
+#   before_action :set_resource_class
+
+#   before_action :set_resource, only: [:show, :edit, :update, :destroy]
+
+#   # エラーになるのでとりあえずコメントオフ
+#   # 継承先でオーバーライドを可能にする
+#   # protected
+
+#   # 一行での書き方
+#   def show; end
+
+#   def edit; end
+
+#   def new
+#     # current_user.idを自動で設定して生成(newだと再度current_user.idが必要)
+#     @resource = @resources.build
+#     # 失敗時も入力を保持するため(redirect_toだと新しいリクエストのため消える)
+#     render :new
+#   end
+
+#   def create
+#     @resource = @resources.build(resource_params)
+#     if @resource.save
+#       # クラスから呼ばれメタ情報（例:material,materials）を保存し、文字列で渡す
+#       flash[:notice] = t('flash_messages.update.success',
+#                           resource: @resource_class.model_name.human)
+#       redirect_to @resource
+#     else
+#       flash.now[:alert] = t('flash_messages.update.failure',
+#                           resource: @resource_class.model_name.human)
+
+#       # renderは200を返すため、スターテスコード422で失敗をユーザーとコンピュータ双方に伝える
+#       render :new, status: :unprocessable_entity
+#     end
+#   end
+
+#   def update
+#     if @resource.update(resource_params)
+#       flash[:notice] = t('flash_messages.update.success',
+#                           resource: @resource_class.model_name.human,
+#                           name: @resource.name)
+#       redirect_to @resource
+#     else
+#       flash.now[:alert] = t('flash_messages.update.failure',
+#                           resource: @resource_class.model_name.human,
+#                           name: @resource.name)
+#       render :edit, status: :unprocessable_entity
+#     end
+#   end
+
+#   def destroy
+#     if @resource.destroy
+#       flash[:notice] = t('flash_messages.destroy.success',
+#                           resource: @resource_class.model_name.human,
+#                           name: @resource.name)
+#       # スターテスコードで次のリクエストをgetに明示的に指示
+#       redirect_to collection_path, status: :see_other
+#     end
+#   end
+
+#   # selfのみで呼び出し可能。レシーバーは指定できない
+#   private
+#   # 継承先のコントローラーから呼ばれるリソースクラスを決定
+#   def set_resource_class
+#     # 例: materials->Material->Materialクラスに変換し、ログインユーザーと繋げヘルパーメソッドを使用可能にする
+#     @resource_class = controller_path.classify.constantize
+#     @resources = current_user.send(controller_name)
+#   end
+
+#   # @resourceの取得共通化
+#   def set_resource
+#     # @resources(例: current_user.materials)から:idに基づいて検索
+#     @resource = @resources.find(params[:id])
+#     instance_variable_set("@#{controller_name.singularize}", @resource)
+#   end
+
+#   # リソース名（:material）を単数形のシンボルで返す→ストロングパラメータ
+#   def resource_name
+#     controller_name.singularize.to_sym
+#   end
+
+#   # ストロングパラメータを子にオーバーライドさせる仕組み
+#   def resource_params
+#     # 継承先で実装されてなければraiseがエラーを発生
+#     raise NotImplementedError, "#{self.class} must implement"
+#   end
+
+#   # リダイレクト先を一覧画面に決定
+#   def collection_path
+#     url_for(controller: controller_name, action: :index)
+#   end
+# end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -26,7 +26,8 @@ class CategoriesController < AuthenticatedController
       redirect_to categories_path, notice: t('flash_messages.create.success', resource: Category.model_name.human, name: @category.name)
     else
       flash.now[:alert] = t('flash_messages.create.failure', resource: Category.model_name.human)
-      render :new
+      # ステータスコード 422 を明示的に指定
+    render :new, status: :unprocessable_entity
     end
   end
 
@@ -39,7 +40,8 @@ class CategoriesController < AuthenticatedController
       redirect_to categories_path, notice: t('flash_messages.update.success', resource: Category.model_name.human, name: @category.name)
     else
       flash.now[:alert] = t('flash_messages.update.failure', resource: Category.model_name.human)
-      render :edit
+      # ステータスコード 422 を明示的に指定
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -9,7 +9,7 @@ class CategoriesController < AuthenticatedController
                               .search_by_name(search_params[:q])
                               # カテゴリ種別による絞り込みをモジュールから
                               .filter_by_category_type(search_params[:category_type])
-    end
+
     # 検索結果のフィードバック表示のため、検索結果をビューに渡す
     @search_term = search_params[:q]
   end
@@ -23,9 +23,12 @@ class CategoriesController < AuthenticatedController
 
     if @category.save
       # I18nキーは 'flash_messages' で統一されており、nameも正しく渡されています
-      redirect_to categories_path, notice: t('flash_messages.create.success', resource: Category.model_name.human, name: @category.name)
+      redirect_to categories_path, notice: t('flash_messages.create.success',
+                                              resource: Category.model_name.human,
+                                              name: @category.name)
     else
-      flash.now[:alert] = t('flash_messages.create.failure', resource: Category.model_name.human)
+      flash.now[:alert] = t('flash_messages.create.failure',
+                            resource: Category.model_name.human)
       # ステータスコード 422 を明示的に指定
     render :new, status: :unprocessable_entity
     end
@@ -37,17 +40,22 @@ class CategoriesController < AuthenticatedController
 
   def update
     if @category.update(category_params)
-      redirect_to categories_path, notice: t('flash_messages.update.success', resource: Category.model_name.human, name: @category.name)
+      redirect_to categories_path, notice: t('flash_messages.update.success',
+                                              resource: Category.model_name.human,
+                                              name: @category.name)
     else
-      flash.now[:alert] = t('flash_messages.update.failure', resource: Category.model_name.human)
-      # ステータスコード 422 を明示的に指定
+      flash.now[:alert] = t('flash_messages.update.failure',
+                            resource: Category.model_name.human)
+      # 失敗時: ステータスコード 422 を明示的に指定
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @category.destroy
-    redirect_to categories_url, notice: t('flash_messages.destroy.success', resource: Category.model_name.human, name: @category.name)
+    redirect_to categories_url, notice: t('flash_messages.destroy.success',
+                                          resource: Category.model_name.human,
+                                          name: @category.name)
   end
 
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,14 +1,18 @@
 class CategoriesController < AuthenticatedController
+  # ページネーションを使用
+  include PaginationConcern
   # privateメソッドの set_category を、edit, update, destroy アクションの前に実行する
   before_action :set_category, only: [:edit, :update, :destroy]
 
   def index
     # モジュールにソート責任を移譲
-    @categories = current_user.categories
+    @categories = apply_pagination(
+      current_user.categories
                               # モデル層に検索を指示し、結果をフィルタリング
                               .search_by_name(search_params[:q])
                               # カテゴリ種別による絞り込みをモジュールから
                               .filter_by_category_type(search_params[:category_type])
+    )
 
     # 検索結果のフィードバック表示のため、検索結果をビューに渡す
     @search_term = search_params[:q]

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,11 +5,10 @@ class CategoriesController < AuthenticatedController
   def index
     # モジュールにソート責任を移譲
     @categories = current_user.categories
-    # モデル層に検索を指示し、結果をフィルタリング
-    @categories = @categories.search_by_name(search_params[:q])
-    # カテゴリ種別による絞り込みの適用
-    if search_params[:category_type].present?
-      @categories = @categories.where(category_type: search_params[:category_type])
+                              # モデル層に検索を指示し、結果をフィルタリング
+                              .search_by_name(search_params[:q])
+                              # カテゴリ種別による絞り込みをモジュールから
+                              .filter_by_category_type(search_params[:category_type])
     end
     # 検索結果のフィードバック表示のため、検索結果をビューに渡す
     @search_term = search_params[:q]

--- a/app/controllers/concerns/pagination_concern.rb
+++ b/app/controllers/concerns/pagination_concern.rb
@@ -1,0 +1,7 @@
+module PaginationConcern
+  extend ActiveSupport::Concern
+  # フィルタリング後のデータをURLと設定に基づいてページネーションを適用
+  def apply_pagination(collection, max_per_page: 20)
+    collection.page(params[:page]).per(max_per_page)
+  end
+end

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,10 +1,13 @@
 class MaterialsController <  AuthenticatedController
+  # ページネーションを使用
+  include PaginationConcern
   before_action :set_material, only: [:show, :edit, :update, :destroy]
   def index
-    @materials = current_user.materials
+    @materials = apply_pagination(current_user.materials
                               # 記載方法の短縮
                               .search_by_name(search_params[:q])
                               .filter_by_category_id(search_params[:category_id])
+    )
 
   end
 

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,17 +1,11 @@
 class MaterialsController <  AuthenticatedController
   before_action :set_material, only: [:show, :edit, :update, :destroy]
+
   def index
-    @materials = Material.all
-
-    # 名前検索の適用
-    if search_params[:q].present?
-      @materials = @materials.search_by_name(search_params[:q])
-    end
-
-    if search_params[:category_id].present?
-      @materials = @materials.filter_by_category_id(search_params[:category_id])
-    end
-
+    @materials = current_user.materials
+                              # 記載方法の短縮
+                              .search_by_name(search_params[:q])
+                              .filter_by_category_id(search_params[:category_id])
   end
 
   def show

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,11 +1,11 @@
 class MaterialsController <  AuthenticatedController
   before_action :set_material, only: [:show, :edit, :update, :destroy]
-
   def index
     @materials = current_user.materials
                               # 記載方法の短縮
                               .search_by_name(search_params[:q])
                               .filter_by_category_id(search_params[:category_id])
+
   end
 
   def show

--- a/app/models/concerns/name_searchable.rb
+++ b/app/models/concerns/name_searchable.rb
@@ -25,7 +25,8 @@ module NameSearchable
     # カテゴリー種別による絞り込みのスコープ
     scope :filter_by_category_type, ->(category_type) do
       # category_type が存在する場合のみ絞り込み適用
-      where(category_type: categories_type) if categories_type.present?
+      # タイポ修正
+      where(category_type: category_type) if category_type.present?
     end
   end
 end

--- a/app/models/concerns/name_searchable.rb
+++ b/app/models/concerns/name_searchable.rb
@@ -21,5 +21,11 @@ module NameSearchable
         where(category_id: category_id)
       end
     end
+
+    # カテゴリー種別による絞り込みのスコープ
+    scope :filter_by_category_type, ->(category_type) do
+      # category_type が存在する場合のみ絞り込み適用
+      where(category_type: categories_type) if categories_type.present?
+    end
   end
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -9,3 +9,8 @@
   <%# ローカル変数 categories に @categories の値を渡す %>
   <%= render 'category_table', categories: @categories %>
 <% end %>
+
+<%# ページネーション設定 %>
+<%= paginate @categories, theme: 'bootstrap-5' %>
+
+

--- a/app/views/materials/index.html.erb
+++ b/app/views/materials/index.html.erb
@@ -10,3 +10,6 @@
 
   <%= render 'material_table', materials: @materials %>
 <% end %>
+
+<%# ページネーション設定 %>
+<%= paginate @materials, theme: 'bootstrap-5' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -91,10 +91,10 @@ production:
   #   <<: *primary_production
   #   database: myapp_production_cache
   #   migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: myapp_production_queue
-    migrations_paths: db/queue_migrate
+  # queue:
+  #   <<: *primary_production
+  #   database: myapp_production_queue
+  #   migrations_paths: db/queue_migrate
   # cable:
   #   <<: *primary_production
   #   database: myapp_production_cable

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,27 @@
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # 最大表示件数を制限。nil にすると無制限
+  # config.max_per_page = nil
+  # 現在のページ番号の左右に表示するページ番号リンクの数を設定
+  # 例: window = 2 で現在が 5 ページの場合、(3 4) [5] (6 7) が表示されます。
+  config.window = 2
+  # 最初と最後のページ番号の周りに表示するページ番号リンクの数
+  # 例: outer_window = 1 の場合、1, 2, ..., 98, 99 のように表示
+  config.outer_window = 1
+  # 最初のページ番号の周りに表示するページ番号リンクの数を設定
+  # config.left = 0
+  # 最後のページ番号の周りに表示するページ番号リンクの数を設定
+  # config.right = 0
+  # ページネーションに使用するスコープメソッド名を設定
+  # 例: User.page(3) の :page の部分
+  # config.page_method_name = :page
+  # URLパラメータの名前を設定。params[:page] の :page の部分
+  # 例: /users?page=3
+  # config.param_name = :page
+  # ナビゲーションバーに表示できる最大のページ数を制限
+  # nil にすると全ページが表示されます（データ量が膨大な場合にパフォーマンス低下の原因）
+  config.max_pages = 20
+  # 最初のページ（page=1）のURLパラメータを省略するかどうかを設定
+  # false の場合、?page=1 が URL に表示されません (SEOに有利)
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
# 概要：設計方針の転換と機能実装

当初、BaseResourceControllerによる継承で共通化を試みましたが、Controllerの**責務過多と密結合の問題**により、この方針を破棄しました。
代わりに、CategoriesとMaterialsの一覧画面に導入予定だったページネーション機能を`PaginationConcern`としてを導入し、実装します。

## 変更内容 

- **責務の分離**:
    Controllerのロジックからページネーション処理（`.page`と`.per`）を完全に分離しました。
- **Concernの導入**: `
    PaginationConcern`を新規作成し、`apply_pagination`メソッドでロジックを共通化。
 **適用範囲**: 
    `CategoriesController`と`MaterialsController`にConcernを適用し、`index`アクションで利用。
- **ビュー**: 
    両一覧ビューに`paginate`ヘルパーを追加。

##  動作確認

1.  **[Categories]**：
    カテゴリが21件以上ある状態で、一覧画面下部にページネーションリンクが表示されること。
2.  **[Materials]**：
    マテリアルが21件以上ある状態で、一覧画面下部にページネーションリンクが表示されること。
3.  **[ページ遷移]**：
    リンクをクリックするとURLの`?page=N`が変わり、正しく次のページに遷移すること。

## レビューポイント

1.  **[責務分離]**：
    `CategoriesController`と`MaterialsController`の`index`アクションに、**ページネーションの具体的な処理（`.page`や`.per`）**が残っていないか？
2  **[Concern]**：
    `PaginationConcern`がシンプルで、**ページネーション以外のロジック**（例：認証や`before_action`など）を含んでいないか？
3.  **[ビュー]**：
    両方の`index.html.erb`で、`paginate`ヘルパーが**`@categories`や`@materials`など正しいインスタンス変数**を参照しているか？
