### PR TITLE
Feat/ 商品一覧に画像表示を追加し、各種ビュー表示とI18nの問題を解決

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client imagemagick && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
@@ -30,7 +30,7 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev node-gyp pkg-config python-is-python3 libmagickwand-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem "rails", "~> 8.0.3"
 # Active Storageの画像変換機能（variants）を使用する場合に必要
 # gem "image_processing", "~> 1.2"
 
+# MiniMagick本体のGemを追加
+gem "mini_magick"
+
 # Rails.cache, Active Job, Action Cableのためのデータベースバックアップアダプタ (Action Cable用)
 gem "solid_cable"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       thin
     marcel (1.1.0)
     matrix (0.4.3)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -466,6 +468,7 @@ DEPENDENCIES
   kamal
   kaminari (= 1.2.2)
   mailcatcher
+  mini_magick
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,6 +34,7 @@ class ProductsController < AuthenticatedController
       :item_number,
       :price,
       :category_id,
+      :image
   )
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,8 +18,10 @@ class ProductsController < AuthenticatedController
     @product = current_user.products.build(product_params)
     # 詳細画面に遷移（レシピ登録へ）
     if @product.save
+      flash[:notice] = t('flash_messages.create.success', resource: Product.model_name.human, name: @product.name)
       redirect_to @product
     else
+      flash.now[:alert] = t('flash_messages.create.failure', resource: Product.model_name.human)
       render :new
     end
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,11 @@
 class ProductsController < AuthenticatedController
+  include PaginationConcern
 
   def index
-    @products = current_user.products.all
+    @products =  apply_pagination(current_user.products
+                              .search_by_name(search_params[:q])
+                              .filter_by_category_id(search_params[:category_id])
+    )
   end
 
   def new
@@ -36,6 +40,10 @@ class ProductsController < AuthenticatedController
       :category_id,
       :image
   )
+  end
+
+  def search_params
+    params.permit(:q, :category_id)
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,7 +22,7 @@ class ProductsController < AuthenticatedController
       redirect_to @product
     else
       flash.now[:alert] = t('flash_messages.create.failure', resource: Product.model_name.human)
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -9,6 +9,9 @@ class Product < ApplicationRecord
   # 多対多
   has_many :materials, through: :product_materials
 
+  # 1対1で画像を紐づけ
+  has_one_attached :image
+
   # バリデーション
   validates :name, presence: true
   validates :item_number, presence: true, uniqueness: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,7 @@
 class Product < ApplicationRecord
+  # 名前検索スコープを組み込み
+  include NameSearchable
+
   # 多対1
   belongs_to :user
   belongs_to :category

--- a/app/views/devise/shared/_tabs.html.erb
+++ b/app/views/devise/shared/_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs mb-4">
   <li class="nav-item">
-    <%= link_to t('devise.sessions.new.sign_in'), new_user_session_path,
+    <%= link_to t('devise.sessions.sign_in'), new_user_session_path,
       data: { turbo_frame: '_top' },
       class: "nav-link #{'active' if current_page?(new_user_session_path)}" %>
   </li>

--- a/app/views/layouts/authenticated_layout.html.erb
+++ b/app/views/layouts/authenticated_layout.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <%# 1. タイトル、CSRFタグ、CSSを戻す！ (必須) %>
+    <%# タイトル、CSRFタグ、CSSを戻す %>
     <title>
       <%= content_for?(:page_title) ? "#{yield(:page_title)} | #{t('application_name')}" : t('application_name') %>
     </title>
@@ -17,7 +17,7 @@
   <body>
     <%# フラッシュメッセージは yield の外に %>
     <div class="container-fluid pt-3">
-      <%# 💡 閉じるボタン付きのAlertコンポーネントに変更 %>
+      <%# 閉じるボタン付きのAlertコンポーネントに変更 %>
       <% if notice %>
         <div class="alert alert-success alert-dismissible fade show" role="alert">
           <%= notice %>

--- a/app/views/materials/_material_table.html.erb
+++ b/app/views/materials/_material_table.html.erb
@@ -1,6 +1,3 @@
-
-
-<% if materials.any? %>
 <table class ="table mt-4">
 <%# 後でカテゴリー別で検索して表示する%>
   <thead class= "table-light">

--- a/app/views/products/_product_fields.html.erb
+++ b/app/views/products/_product_fields.html.erb
@@ -1,3 +1,9 @@
+<%# 画像 %>
+<div class="mb-3">
+  <%= f.label :image, '画像', class: "form-label" %>
+  <%= f.file_field :image, class: "form-control" %>
+</div>
+
 <%# 製品名 %>
 <div class="mb-3">
   <%= f.label :name, class: "form-label" %>

--- a/app/views/products/_product_table.html.erb
+++ b/app/views/products/_product_table.html.erb
@@ -2,7 +2,7 @@
   <thead class="table-light">
     <tr>
     <%# Product.human_attribute_name を利用して属性名を表示 %>
-    <th>画像</th>
+    <th><%= Product.human_attribute_name(:image) %></th>
     <th><%= Product.human_attribute_name(:category_id) %></th>
     <th><%= Product.human_attribute_name(:item_number) %></th>
     <th><%= Product.human_attribute_name(:name) %></th>

--- a/app/views/products/_product_table.html.erb
+++ b/app/views/products/_product_table.html.erb
@@ -2,6 +2,7 @@
   <thead class="table-light">
     <tr>
     <%# Product.human_attribute_name を利用して属性名を表示 %>
+    <th>画像</th>
     <th><%= Product.human_attribute_name(:category_id) %></th>
     <th><%= Product.human_attribute_name(:item_number) %></th>
     <th><%= Product.human_attribute_name(:name) %></th>
@@ -12,7 +13,16 @@
   <tbody>
   <% products.each do |product| %>
     <tr>
-      <%# カテゴリ名 %>
+      <%# 属性名 %>
+      <%# 画像があればリサイズして表示 %>
+      <td>
+        <% if product.image.attached? %>
+          <%= image_tag product.image.variant(resize_to_limit: [50, 50]),
+                        class: "img-thumbnail"%>
+        <% else %>
+          -
+        <% end %>
+      </td>
       <td><%= product.category.name %></td>
       <td><%= product.item_number %></td>
       <td><%= product.name %></td>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -9,5 +9,7 @@
     search_target: :category_id %>
 
   <%= render 'product_table', products: @products %>
-
 <% end %>
+
+<%# ページネーション設定 %>
+<%= paginate @products, theme: 'bootstrap-5' %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -3,6 +3,11 @@
             title: t('.title'),
             new_path: new_product_path do %>
 
+    <%# 共有検索フォームにcategory_idを渡す %>
+    <%= render 'shared/search_form',
+    form_path: products_path,
+    search_target: :category_id %>
+
   <%= render 'product_table', products: @products %>
 
 <% end %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,7 +1,7 @@
 <%# フォームラッパーにローカル変数を渡し、フォームビルダーオブジェクトが生成 %>
 <%#  orm_wrappeで生成したfをここでproduct_fieldsに渡す %>
 <%= render 'shared/form_wrapper',
-    title: t('title'),
+    title: t('.title'),
     resource: @product,
     back_path: products_path,
     form_options: { multipart: true } do |f| %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -3,7 +3,8 @@
 <%= render 'shared/form_wrapper',
     title: t('title'),
     resource: @product,
-    back_path: products_path do |f| %>
+    back_path: products_path,
+    form_options: { multipart: true } do |f| %>
 
   <%= render 'product_fields', f: f %>
 <% end %>

--- a/app/views/shared/_form_wrapper.html.erb
+++ b/app/views/shared/_form_wrapper.html.erb
@@ -7,7 +7,9 @@
 <%# resource: モデルインスタンス, back_path: 戻り先パス をローカル変数として受け取る %>
 <div id="<%= dom_id(resource, :form) %>">
 
-  <%= form_with(model: resource) do |f| %>
+  <%= form_with(model: resource,
+                local: true,
+                **(defined?(form_options) ? form_options : {})) do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,9 @@ module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
+    # 画像のリサイズ
+    config.active_storage.variant_processor = :mini_magick
+
 
     #日本語ロケールの設定
     config.i18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -104,8 +104,10 @@ ja:
     sessions:
       new:
         title: "ログイン"
+        submit: 'ログイン'
       signed_in: "ログインしました"
       signed_out: "ログアウトしました"
+      sign_in: "ログイン"
       sign_out: "ログアウト"
 
     confirmations:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
       dashboard: "ダッシュボード"
       category_management: "カテゴリー管理"
       material_management: "原材料管理"
+      product_management: "商品管理"
       account_settings: "アカウント設定"
     welcome_message: "ようこそ！ %{name} さんのダッシュボード"
 
@@ -41,6 +42,12 @@ ja:
       title: "%{material_name} - 詳細 "
     edit:
       title: "%{material_name} - 編集 "
+
+  products:
+    new:
+      title: "商品登録"
+    index:
+      title: "商品一覧"
 
   # 汎用的なテキストは ja: 直下  にまとめる
   common:
@@ -158,6 +165,7 @@ ja:
       user: "アカウント"
       category: "カテゴリー"
       material: "原材料"
+      product: "商品"
 
     attributes:
       user:
@@ -183,3 +191,11 @@ ja:
         unit_weight_for_order: "重量（発注単位）"
         category_id: "カテゴリー"
         category: "カテゴリー"
+
+      product:
+        name: "商品名"
+        item_number: "品番"
+        price: "売価"
+        category_id: "カテゴリー"
+        category: "カテゴリー"
+        image: "画像"

--- a/db/migrate/20251008083833_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20251008083833_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20251008094213_remove_image_url_from_products.rb
+++ b/db/migrate/20251008094213_remove_image_url_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveImageUrlFromProducts < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :products, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_08_011106) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_08_094213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
@@ -52,7 +80,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_011106) do
     t.string "name", null: false
     t.integer "price", null: false
     t.string "item_number", null: false
-    t.string "image_url"
     t.bigint "user_id", null: false
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
@@ -74,6 +101,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_011106) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "users"
   add_foreign_key "materials", "categories"
   add_foreign_key "materials", "users"


### PR DESCRIPTION
# 概要
商品一覧画面のテーブルに「画像」カラムを追加し、Active Storage経由で登録された商品のサムネイル画像を表示するようにしました。
また、これまで残っていたすべてのビュー表示の問題と、付随する機能の安定化をまとめて実施しました。

## 変更内容
### タイトル表示の修正:
- 商品一覧・登録画面で「Title」と表示されていたメイン見出しを、t('.title') を使用するように修正し、I18nキー（「商品一覧」「商品登録」）から正しくタイトルを取得できるようにしました。

### Devise翻訳の修正:
- ログイン画面で発生していた translation missing エラーを解消するため、ja.yml に不足していたログインボタン (submit) やリンク (sign_in) の翻訳キーを追記・修正しました。

### フラッシュメッセージとフォームの安定化:
- ProductsController#create にて登録失敗時、HTTPステータスコード 422 Unprocessable Entity を返すように修正しました。

### ページネーションの組み込み:
- 商品一覧ビューの最後に <%= paginate @products, theme: 'bootstrap-5' %> を組み込み、kaminariによるページング表示を有効にしました。

## レビューポイント
- [ ] 商品一覧画面で、サムネイル画像とページネーションが表示されていること。
- [ ] ログイン画面のリンクやボタンがすべて日本語で表示されていること。
- [ ] 商品登録画面で、タイトルが「商品登録」となり、バリデーションエラー時にエラーメッセージと失敗メッセージが表示されること。

## 変更ファイル一覧
- app/views/products/index.html.erb	画像カラムの追加、タイトル渡し方を t('.title') へ修正、paginate ヘルパーを追加
- app/views/products/new.html.erb	タイトル渡し方を t('.title') へ修正、バリデーションエラー表示部分を追加
- app/controllers/products_controller.rb	create アクションに status: :unprocessable_entity を追加
- config/locales/ja.yml	Deviseキーと products 関連タイトルの不足・誤りを修正
- app/models/product.rb Active Storage関連の定義（has_one_attached :image）を追加
